### PR TITLE
Add solana to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ typing-extensions==3.7.4.2
 ecdsa==0.16.0
 pysha3==1.0.2
 eth-keys==0.3.3
+solana


### PR DESCRIPTION
Fixed problem with `ModuleNotFoundError: No module named 'solana'`