### PR TITLE
Split contract account

### DIFF
--- a/proxy/plugin/solana_rest_api_tools.py
+++ b/proxy/plugin/solana_rest_api_tools.py
@@ -39,11 +39,18 @@ rentid = "SysvarRent111111111111111111111111111111111"
 system = "11111111111111111111111111111111"
 
 ACCOUNT_INFO_LAYOUT = cStruct(
+    "tag" / Int8ul,
     "eth_acc" / Bytes(20),
     "nonce" / Int8ul,
     "trx_count" / Bytes(8),
     "signer_acc" / Bytes(32),
-    "code_size" / Int32ul
+    "code_acc" / Bytes(32),
+)
+
+CODE_INFO_LAYOUT = cStruct(
+    "tag" / Int8ul,
+    "owner" / Bytes(20),
+    "code_size" / Bytes(4),
 )
 
 CREATE_ACCOUNT_LAYOUT = cStruct(

--- a/proxy/plugin/solana_rest_api_tools.py
+++ b/proxy/plugin/solana_rest_api_tools.py
@@ -279,6 +279,7 @@ def call_emulated(base_account, contract_id, caller_id, data):
 def call_signed(acc, client, ethTrx):
     sender_ether = bytes.fromhex(ethTrx.sender())
     (contract_sol, _) = create_program_address(ethTrx.toAddress.hex(), evm_loader_id, acc.public_key())
+    (code_sol, _, _) = create_seed_address(ethTrx.toAddress.hex(), evm_loader_id, acc.public_key())
     (sender_sol, _) = create_program_address(sender_ether.hex(), evm_loader_id, acc.public_key())
 
     trx = Transaction()
@@ -295,7 +296,7 @@ def call_signed(acc, client, ethTrx):
     for acc_desc in output_json["accounts"]:
         call_inner_eth = bytes.fromhex(acc_desc['address'][2:])
         (call_inner, _) = create_program_address(call_inner_eth, evm_loader_id, acc.public_key())
-        if call_inner not in [contract_sol, sender_sol]:
+        if call_inner not in [contract_sol, code_sol, sender_sol]:
             add_keys_05.append(AccountMeta(pubkey=call_inner, is_signer=False, is_writable=acc_desc["writable"]))
             if acc_desc["new"] == True:    
                 logger.debug("Create solana account %s %s", call_inner_eth, call_inner)
@@ -312,6 +313,7 @@ def call_signed(acc, client, ethTrx):
         data=bytearray.fromhex("05") + sender_ether + ethTrx.signature() + ethTrx.unsigned_msg(),
         keys=[
             AccountMeta(pubkey=contract_sol, is_signer=False, is_writable=True),
+            AccountMeta(pubkey=code_sol, is_signer=False, is_writable=True),
             AccountMeta(pubkey=sender_sol, is_signer=False, is_writable=True),
             AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
             AccountMeta(pubkey=evm_loader_id, is_signer=False, is_writable=False),
@@ -389,9 +391,11 @@ def deploy_contract(acc, client, ethTrx):
     #rlp = pack(sender_ether, ethTrx.nonce or None)
     contract_eth = keccak_256(rlp.encode((sender_ether, ethTrx.nonce))).digest()[-20:]
     (contract_sol, contract_nonce) = create_program_address(contract_eth.hex(), evm_loader_id, acc.public_key())
+    (code_sol, code_nonce, code_seed) = create_seed_address(contract_eth.hex(), evm_loader_id, acc.public_key())
 
     logger.debug("Legacy contract address ether: %s", contract_eth.hex())
     logger.debug("Legacy contract address solana: %s %s", contract_sol, contract_nonce)
+    logger.debug("Legacy code address solana: %s %s", code_sol, code_nonce)
 
     # Create transaction holder account (if not exists)
     seed = bytes("1236", 'utf8')
@@ -440,13 +444,15 @@ def deploy_contract(acc, client, ethTrx):
     if sender_sol_info['result']['value'] is None:
         trx.add(createEtherAccountTrx(client, sender_ether, evm_loader_id, acc)[0])
 
-    trx.add(createEtherAccountTrx(client, contract_eth, evm_loader_id, acc, space=65+len(msg)+2048)[0])
+    trx.add(createAccountWithSeed(acc.public_key(), acc.public_key(), code_seed, 10**9, CODE_INFO_LAYOUT.sizeof()+len(msg)+2048, PublicKey(evm_loader_id)))
+    trx.add(createEtherAccountTrx(client, contract_eth, evm_loader_id, acc, code_sol)[0])
     trx.add(TransactionInstruction(program_id=evm_loader_id,
                                    data=bytes.fromhex('08'),
                                    keys=[
                                        AccountMeta(pubkey=holder, is_signer=False, is_writable=True),
-                                       AccountMeta(pubkey=sender_sol, is_signer=False, is_writable=True),
                                        AccountMeta(pubkey=contract_sol, is_signer=False, is_writable=True),
+                                       AccountMeta(pubkey=code_sol, is_signer=False, is_writable=True),
+                                       AccountMeta(pubkey=sender_sol, is_signer=False, is_writable=True),
                                        AccountMeta(pubkey=evm_loader_id, is_signer=False, is_writable=False),
                                        AccountMeta(pubkey=PublicKey(sysvarclock), is_signer=False, is_writable=False),
                                    ]))


### PR DESCRIPTION
## Add support for splitting ethereum contract account to account and code accounts to proxy.
Uses "create-program-address" to create solana accounts for ethereum addresses(0x02000000 evm_loader instruction).
For contract account creation adds Code Account to keys.
Code account created with CreateAccountWithSeed system instruction.
Adds Code and Account layouts.
Adds Code Account to calls to evm_loader.

### Depends on:
Cyber-Core/solana#11
Cyber-Core/solana-program-library#108
