### PR TITLE
Update to solana v1.6.7 #63

### DIFF
--- a/proxy/docker-compose-test.yml
+++ b/proxy/docker-compose-test.yml
@@ -3,7 +3,7 @@ version: "2.1"
 services:
   solana:
     container_name: solana
-    image: cybercoredev/solana:v1.4.25-resources
+    image: cybercoredev/solana:v1.6.7-resources
     environment:
       - SOLANA_URL=http://solana:8899
       - RUST_LOG=solana_runtime::system_instruction_processor=trace,solana_runtime::message_processor=debug,solana_bpf_loader=debug,solana_rbpf=debug

--- a/proxy/run-proxy.sh
+++ b/proxy/run-proxy.sh
@@ -17,7 +17,7 @@ done
 
 solana airdrop 1000
 solana-deploy deploy /spl/bin/evm_loader.so > evm_loader_id
-export EVM_LOADER=$(cat evm_loader_id | tail -n 1 | python3 -c 'import sys, json; data=json.load(sys.stdin); print(data["programId"]);')
+export EVM_LOADER=$(cat evm_loader_id | sed '/Program Id: \([0-9A-Za-z]\+\)/,${s//\1/;b};s/^.*$//;$q1')
 echo EVM_LOADER=$EVM_LOADER
 
 echo run-proxy


### PR DESCRIPTION
Use the last version of the solana CLI to deploy the evm_loader contract (v1.6.7)