### PR TITLE
Print measurements info for evm_loader instructions #76

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,6 +12,7 @@ steps:
     artifact_paths:
       - "proxy.log"
       - "solana.log"
+      - "measurements.log"
 
   - wait
 

--- a/.buildkite/steps/deploy-test.sh
+++ b/.buildkite/steps/deploy-test.sh
@@ -40,6 +40,7 @@ docker-compose -f proxy/docker-compose-test.yml up -d
 function cleanup_docker {
     docker logs proxy >proxy.log 2>&1
     docker logs solana >solana.log 2>&1
+    grep 'send_measured_transaction' <proxy.log >measurements.log
     echo "Cleanup docker-compose..."
     docker-compose -f proxy/docker-compose-test.yml down
     echo "Cleanup docker-compose done."

--- a/.buildkite/steps/deploy-test.sh
+++ b/.buildkite/steps/deploy-test.sh
@@ -45,7 +45,7 @@ function cleanup_docker {
     docker-compose -f proxy/docker-compose-test.yml down
     echo "Cleanup docker-compose done."
 
-    if grep '\[I\] send_measured_transaction' <measurements.log; then
+    if grep '\[E\] send_measured_transaction' <measurements.log; then
         echo 'Failed to get measurements'
         exit 1
     fi

--- a/.buildkite/steps/deploy-test.sh
+++ b/.buildkite/steps/deploy-test.sh
@@ -44,6 +44,11 @@ function cleanup_docker {
     echo "Cleanup docker-compose..."
     docker-compose -f proxy/docker-compose-test.yml down
     echo "Cleanup docker-compose done."
+
+    if grep '\[I\] send_measured_transaction' <measurements.log; then
+        echo 'Failed to get measurements'
+        exit 1
+    fi
 }
 trap cleanup_docker EXIT
 sleep 10

--- a/proxy/plugin/solana_rest_api_tools.py
+++ b/proxy/plugin/solana_rest_api_tools.py
@@ -124,7 +124,6 @@ def create_storage_account(client, funding, base, seed):
     if client.get_balance(storage)['result']['value'] == 0:
         trx = Transaction()
         trx.add(createAccountWithSeed(funding.public_key(), base.public_key(), seed, 10**9, 128*1024, PublicKey(evm_loader_id)))
-        #client.send_transaction(trx, funding, opts=TxOpts(skip_confirmation=True, preflight_commitment="recent"))
         send_transaction(client, trx, funding)
 
     return storage
@@ -344,7 +343,6 @@ def sol_instr_10_continue(acc, client, step_count, accounts):
                                keys= accounts))
 
         logger.debug("Continue")
-        #result = client.send_transaction(trx, acc, opts=TxOpts(skip_confirmation=False, preflight_commitment="recent"))
         result = send_measured_transaction(client, trx, acc)
         # print(result["result"])
         acc_meta_lst = result["result"]["transaction"]["message"]["accountKeys"]
@@ -413,7 +411,6 @@ def call_signed(acc, client, ethTrx, storage, steps):
         ))
 
     logger.debug("Partial call")
-    #result = client.send_transaction(trx, acc, opts=TxOpts(skip_confirmation=True, preflight_commitment="recent"))
     result = send_measured_transaction(client, trx, acc)
     signature = result["result"]["transaction"]["signatures"][0]
     confirm_transaction(client, signature)
@@ -458,8 +455,6 @@ def createEtherAccountTrx(client, ether, evm_loader_id, signer, code_acc=None):
 
 def createEtherAccount(client, ether, evm_loader_id, signer, space=0):
     (trx, sol) = createEtherAccountTrx(client, ether, evm_loader_id, signer, space)
-    #result = client.send_transaction(trx, signer,
-    #        opts=TxOpts(skip_confirmation=False, preflight_commitment="recent"))
     result = send_transaction(client, trx, signer)
     logger.debug('createEtherAccount result: %s', result)
     return sol
@@ -494,8 +489,6 @@ def deploy_contract(acc, client, ethTrx, storage, steps):
         trx = Transaction()
         trx.add(createAccountWithSeed(acc.public_key(), acc.public_key(), seed, 10 ** 9, 128 * 1024,
                                       PublicKey(evm_loader_id)))
-        #receipt = client.send_transaction(trx, acc,
-        #        opts=TxOpts(skip_confirmation=True, preflight_commitment="recent"))['result']
         result = send_measured_transaction(client, trx, acc)
         signature = result["result"]["transaction"]["signatures"][0]
         confirm_transaction(client, signature)
@@ -538,8 +531,6 @@ def deploy_contract(acc, client, ethTrx, storage, steps):
     if client.get_balance(contract_sol, commitment='recent')['result']['value'] == 0:
         trx.add(createEtherAccountTrx(client, contract_eth, evm_loader_id, acc, code_sol)[0])
     if len(trx.instructions):
-        #result = client.send_transaction(trx, acc,
-        #        opts=TxOpts(skip_confirmation=True, preflight_commitment="recent"))
         result = send_measured_transaction(client, trx, acc)
         signature = result["result"]["transaction"]["signatures"][0]
         confirm_transaction(client, signature)
@@ -558,8 +549,6 @@ def deploy_contract(acc, client, ethTrx, storage, steps):
     trx.add(TransactionInstruction(program_id=evm_loader_id,
                            data=bytearray.fromhex("0b") + (0).to_bytes(8, byteorder='little'),
                            keys=accounts))
-    #result = client.send_transaction(trx, acc,
-    #                                 opts=TxOpts(skip_confirmation=False, preflight_commitment="recent"))
     result = send_measured_transaction(client, trx, acc)
 
     # ExecuteTrxFromAccountDataIterative

--- a/proxy/plugin/solana_rest_api_tools.py
+++ b/proxy/plugin/solana_rest_api_tools.py
@@ -333,6 +333,7 @@ def send_measured_transaction(client, trx, acc):
         for m in measurements: logger.info(json.dumps(m))
     except Exception as err:
         logger.error("Can't get measurements %s"%err)
+        logger.info("Failed result: %s"%json.dumps(result, indent=3))
     return result
 
 def sol_instr_10_continue(acc, client, step_count, accounts):


### PR DESCRIPTION
Extract measurements info from the Solana receipt for evm_loader transactions.
Collect all measurements into `measurements.log` available in build artifacts.