### PR TITLE
Cancel failed transaction #82

### DIFF
--- a/proxy/plugin/solana_rest_api_tools.py
+++ b/proxy/plugin/solana_rest_api_tools.py
@@ -350,7 +350,7 @@ def sol_instr_10_continue(acc, client, step_count, accounts):
         result = object()
         try:
             result = send_measured_transaction(client, trx, acc)
-        except SendTransactionError:
+        except Exception:
             sol_instr_12_cancel(acc, client, accounts)
             raise
 

--- a/proxy/plugin/solana_rest_api_tools.py
+++ b/proxy/plugin/solana_rest_api_tools.py
@@ -367,17 +367,12 @@ def sol_instr_10_continue(acc, client, step_count, accounts):
                 if (data[0] == 6):
                     return result['result']['transaction']['signatures'][0]
 
-def sol_instr_12_cancel(acc, client, accounts, raise_exception = True):
+def sol_instr_12_cancel(acc, client, accounts):
     trx = Transaction()
     trx.add(TransactionInstruction(program_id=evm_loader_id, data=bytearray.fromhex("0C"), keys=accounts))
 
     logger.debug("Cancel")
-    result = send_measured_transaction(client, trx, acc)[0]
-
-    if raise_exception:
-        raise Exception("Failed to continue transaction -> canceled")
-    else:
-        return result
+    result = send_measured_transaction(client, trx, acc)
 
 
 def call_signed(acc, client, ethTrx, storage, steps):

--- a/proxy/plugin/solana_rest_api_tools.py
+++ b/proxy/plugin/solana_rest_api_tools.py
@@ -357,7 +357,8 @@ def sol_instr_10_continue(acc, client, step_count, accounts):
 
         logger.debug("Continue")
         (result, success) = send_measured_transaction(client, trx, acc, True)
-        result = send_measured_transaction(client, trx, acc)
+        if not success:
+            sol_instr_12_cancel(acc, client, accounts)
 
         # print(result["result"])
         acc_meta_lst = result["result"]["transaction"]["message"]["accountKeys"]
@@ -371,6 +372,18 @@ def sol_instr_10_continue(acc, client, step_count, accounts):
                 data = b58decode(instruction['data'])
                 if (data[0] == 6):
                     return result['result']['transaction']['signatures'][0]
+
+def sol_instr_12_cancel(acc, client, accounts, raise_exception = True):
+    trx = Transaction()
+    trx.add(TransactionInstruction(program_id=evm_loader_id, data=bytearray.fromhex("0C"), keys=accounts))
+
+    logger.debug("Cancel")
+    result = send_measured_transaction(client, trx, acc)[0]
+
+    if raise_exception:
+        raise Exception("Failed to continue transaction -> canceled")
+    else:
+        return result
 
 
 def call_signed(acc, client, ethTrx, storage, steps):


### PR DESCRIPTION
If send_transaction returns exception for continue transactions to solana - intercept it and return specific result that will force call to cancel instruction to solana.