### PR TITLE
Send transaction time optimization #97

### DIFF
--- a/proxy/plugin/solana_rest_api.py
+++ b/proxy/plugin/solana_rest_api.py
@@ -324,10 +324,10 @@ class EthereumModel:
             try:
                 contract_eth = None
                 if (not trx.toAddress):
-                    (signature, contract_eth) = deploy_contract(self.signer,  self.client, trx, self.storage, steps=2000)
+                    (signature, contract_eth) = deploy_contract(self.signer,  self.client, trx, self.storage, steps=1000)
                     #self.contract_address[eth_signature] = contract_eth
                 else:
-                    signature = call_signed(self.signer, self.client, trx, self.storage, steps=2000)
+                    signature = call_signed(self.signer, self.client, trx, self.storage, steps=1000)
 
                 eth_signature = '0x' + bytes(Web3.keccak(bytes.fromhex(rawTrx[2:]))).hex()
                 logger.debug('Transaction signature: %s %s', signature, eth_signature)

--- a/proxy/plugin/solana_rest_api_tools.py
+++ b/proxy/plugin/solana_rest_api_tools.py
@@ -213,7 +213,7 @@ class neon_cli:
             logger.debug("ERR: neon-cli error {}".format(err))
             raise
 
-def confirm_transaction(client, tx_sig, confirmations=1):
+def confirm_transaction(client, tx_sig, confirmations=0):
     """Confirm a transaction."""
     TIMEOUT = 30  # 30 seconds  pylint: disable=invalid-name
     elapsed_time = 0
@@ -227,7 +227,7 @@ def confirm_transaction(client, tx_sig, confirmations=1):
                status['confirmationStatus'] == 'confirmed' and status['confirmations'] >= confirmations):
 #            logger.debug('Confirmed transaction:', resp)
                 return
-        sleep_time = 1
+        sleep_time = 0.1
         time.sleep(sleep_time)
         elapsed_time += sleep_time
     #if not resp["result"]:


### PR DESCRIPTION
* decrease time for waiting for confirmation
* wait only block generation (confirmation=0)
* increase steps to 1000 (selected empirically)