### PR TITLE
Find and Cancel hanged transactions #196

### DIFF
--- a/proxy/deploy-test.sh
+++ b/proxy/deploy-test.sh
@@ -8,6 +8,12 @@ export $(/spl/bin/neon-cli --evm_loader JxujFZpNBPADbfw2MnPPgnnFGruzp2ELSFWPQgrj
 
 curl -v --header "Content-Type: application/json" --data '{"method":"eth_blockNumber","id":1,"jsonrpc":"2.0","params":[]}' $PROXY_URL
 
+solana config set -u $SOLANA_URL
+solana config get
+solana address
+solana airdrop 1000
+solana balance
+
 python3 -m unittest discover -v -p 'test*.py'
 
 echo "Deploy test success"

--- a/proxy/indexer/solana_receipts_update.py
+++ b/proxy/indexer/solana_receipts_update.py
@@ -7,6 +7,7 @@ import logging
 from solana.rpc.api import Client
 from multiprocessing.dummy import Pool as ThreadPool
 from sqlitedict import SqliteDict
+from typing import Dict, Union
 
 try:
     from utils import check_error, get_trx_results, get_trx_receipts
@@ -68,7 +69,12 @@ class Indexer:
 
         counter = 0
         while (continue_flag):
-            result = self.client.get_signatures_for_address(evm_loader_id, before=minimal_tx)
+            opts: Dict[str, Union[int, str]] = {}
+            if minimal_tx:
+                opts["before"] = minimal_tx
+            opts["commitment"] = "confirmed"
+            result = self.client._provider.make_request("getSignaturesForAddress", evm_loader_id, opts)
+
             logger.debug("{:>3} get_signatures_for_address {}".format(counter, len(result["result"])))
             counter += 1
 

--- a/proxy/indexer/solana_receipts_update.py
+++ b/proxy/indexer/solana_receipts_update.py
@@ -17,6 +17,7 @@ except ImportError:
 
 solana_url = os.environ.get("SOLANA_URL", "https://api.devnet.solana.com")
 evm_loader_id = os.environ.get("EVM_LOADER", "eeLSJgWzzxrqKv1UxtRVVH8FX3qCQWUs9QuAjJpETGU")
+PARALLEL_REQUESTS = int(os.environ.get("PARALLEL_REQUESTS", "2"))
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -115,7 +116,7 @@ class Indexer:
                     break
 
         logger.debug("start getting receipts")
-        pool = ThreadPool(2)
+        pool = ThreadPool(PARALLEL_REQUESTS )
         results = pool.map(self.get_tx_receipts, poll_txs)
 
         # count = 0

--- a/proxy/indexer/solana_receipts_update.py
+++ b/proxy/indexer/solana_receipts_update.py
@@ -314,8 +314,7 @@ class Indexer:
 
                                 del continue_table[storage_account]
                             else:
-                                # logger.debug("{} {}".format(signature, storage_account))
-                                self.blocked_storages.add(storage_account)
+                                self.add_hunged_storage(trx, storage_account)
 
                         elif instruction_data[0] == 0x0a: # Continue
                             # logger.debug("{:>10} {:>6} Continue 0x{}".format(slot, counter, instruction_data.hex()))
@@ -329,8 +328,7 @@ class Indexer:
                                 if got_result is not None:
                                     continue_table[storage_account] =  ContinueStruct(signature, got_result)
                                 else:
-                                    # logger.debug("{} {}".format(signature, storage_account))
-                                    self.blocked_storages.add(storage_account)
+                                    self.add_hunged_storage(trx, storage_account)
 
 
                         elif instruction_data[0] == 0x0b: # ExecuteTrxFromAccountDataIterative
@@ -349,8 +347,7 @@ class Indexer:
                                 else:
                                     holder_table[holder_account] = HolderStruct(storage_account)
                             else:
-                                # logger.debug("{} {}".format(signature, storage_account))
-                                self.blocked_storages.add(storage_account)
+                                self.add_hunged_storage(trx, storage_account)
 
 
                         elif instruction_data[0] == 0x0c: # Cancel
@@ -384,8 +381,7 @@ class Indexer:
                                 if got_result is not None:
                                     self.submit_transaction(eth_trx, eth_signature, from_address, got_result, [signature])
                                 else:
-                                    # logger.debug("{} {}".format(signature, storage_account))
-                                    self.blocked_storages.add(storage_account)
+                                    self.add_hunged_storage(trx, storage_account)
 
                         elif instruction_data[0] == 0x0d:
                             # logger.debug("{:>10} {:>6} ExecuteTrxFromAccountDataIterativeOrContinue 0x{}".format(slot, counter, instruction_data.hex()))
@@ -408,8 +404,7 @@ class Indexer:
                                     continue_table[storage_account] =  ContinueStruct(signature, got_result)
                                     holder_table[holder_account] = HolderStruct(storage_account)
                                 else:
-                                    # logger.debug("{} {}".format(signature, storage_account))
-                                    self.blocked_storages.add(storage_account)
+                                    self.add_hunged_storage(trx, storage_account)
 
                         if instruction_data[0] > 0x0e:
                             logger.debug("{:>10} {:>6} Unknown 0x{}".format(slot, counter, instruction_data.hex()))
@@ -476,6 +471,11 @@ class Indexer:
                 time.sleep(1)
 
         return (slot, block_hash)
+
+
+    def add_hunged_storage(self, trx, storage):
+        if abs(trx['slot'] - self.current_slot) > 30:
+            self.blocked_storages.add(storage)
 
 
 def run_indexer():

--- a/proxy/indexer/solana_receipts_update.py
+++ b/proxy/indexer/solana_receipts_update.py
@@ -70,14 +70,10 @@ class Indexer:
                 self.gather_blocks()
                 logger.debug("Unlock accounts")
                 self.canceller.unlock_accounts(self.blocked_storages)
-                self.blocked_storages.clear()
+                self.blocked_storages = set()
             except Exception as err:
                 logger.debug("Got exception while indexing. Type(err):%s, Exception:%s", type(err), err)
 
-            if loop:
-                time.sleep(1)
-            else:
-                break
 
     def gather_unknown_transactions(self):
         poll_txs = set()
@@ -354,7 +350,7 @@ class Indexer:
                             # logger.debug("{:>10} {:>6} Cancel 0x{}".format(slot, counter, instruction_data.hex()))
 
                             storage_account = trx['transaction']['message']['accountKeys'][instruction['accounts'][0]]
-                            continue_table[storage_account] = ContinueStruct(signature, (None, "0x0", None, None, trx['slot']))
+                            continue_table[storage_account] = ContinueStruct(signature, ([], "0x0", 0, [], trx['slot']))
 
                         elif instruction_data[0] == 0x0c:
                             # logger.debug("{:>10} {:>6} PartialCallOrContinueFromRawEthereumTX 0x{}".format(slot, counter, instruction_data.hex()))
@@ -474,7 +470,7 @@ class Indexer:
 
 
     def add_hunged_storage(self, trx, storage):
-        if abs(trx['slot'] - self.current_slot) > 30:
+        if abs(trx['slot'] - self.current_slot) > 16:
             self.blocked_storages.add(storage)
 
 

--- a/proxy/indexer/solana_receipts_update.py
+++ b/proxy/indexer/solana_receipts_update.py
@@ -243,12 +243,14 @@ class Indexer:
                                             # raise
 
                                         del holder_table[write_account]
-                                    except rlp.exceptions.DecodingError:
-                                        logger.debug("DecodingError")
-                                    except rlp.exceptions.ObjectDeserializationError:
+                                    except rlp.exceptions.DecodingError or rlp.exceptions.ObjectDeserializationError:
                                         logger.debug("DecodingError")
                                     except Exception as err:
-                                        logger.debug("could not parse trx {}".format(err))
+                                        if str(err).startswith("unhashable type"):
+                                            pass
+                                        else:
+                                            logger.debug("could not parse trx {}".format(err))
+                                            raise
 
                         elif instruction_data[0] == 0x01: # Finalize
                             # logger.debug("{:>10} {:>6} Finalize 0x{}".format(slot, counter, instruction_data.hex()))

--- a/proxy/indexer/solana_receipts_update.py
+++ b/proxy/indexer/solana_receipts_update.py
@@ -24,6 +24,9 @@ PARALLEL_REQUESTS = int(os.environ.get("PARALLEL_REQUESTS", "2"))
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
+DEVNET_HISTORY_START = "7BdwyUQ61RUZP63HABJkbW66beLk22tdXnP69KsvQBJekCPVaHoJY47Rw68b3VV1UbQNHxX3uxUSLfiJrfy2bTn"
+HISTORY_START = [DEVNET_HISTORY_START]
+
 UPDATE_BLOCK_COUNT = PARALLEL_REQUESTS * 16
 
 class HolderStruct:
@@ -105,7 +108,7 @@ class Indexer:
                 solana_signature = tx["signature"]
                 slot = tx["slot"]
 
-                if solana_signature == "7BdwyUQ61RUZP63HABJkbW66beLk22tdXnP69KsvQBJekCPVaHoJY47Rw68b3VV1UbQNHxX3uxUSLfiJrfy2bTn":
+                if solana_signature in HISTORY_START:
                     logger.debug(solana_signature)
                     continue_flag = False
                     break

--- a/proxy/indexer/solana_receipts_update.py
+++ b/proxy/indexer/solana_receipts_update.py
@@ -417,7 +417,7 @@ class Indexer:
             for rec in logs:
                 rec['transactionHash'] = eth_signature
 
-        logger.debug(eth_signature + " " + status)
+        # logger.debug(eth_signature + " " + status)
 
         self.ethereum_trx[eth_signature] = {
             'eth_trx': eth_trx,

--- a/proxy/indexer/solana_receipts_update.py
+++ b/proxy/indexer/solana_receipts_update.py
@@ -79,9 +79,6 @@ class Indexer:
 
         counter = 0
         while (continue_flag):
-            if counter > 1000:
-                break
-
             opts: Dict[str, Union[int, str]] = {}
             if minimal_tx:
                 opts["before"] = minimal_tx
@@ -303,9 +300,7 @@ class Indexer:
 
                                 del continue_table[storage_account]
                             else:
-                                logger.debug("Storage not found")
-                                logger.debug(signature)
-                                logger.debug(storage_account)
+                                logger.debug("LOST_TRX\t{}\t{}".format(signature, storage_account))
                                 pass
 
                         elif instruction_data[0] == 0x0a: # Continue
@@ -320,9 +315,7 @@ class Indexer:
                                 if got_result is not None:
                                     continue_table[storage_account] =  ContinueStruct(signature, got_result)
                                 else:
-                                    logger.error("Result not found")
-                                    logger.debug(signature)
-                                    logger.debug(storage_account)
+                                    logger.debug("LOST_TRX\t{}\t{}".format(signature, storage_account))
 
 
                         elif instruction_data[0] == 0x0b: # ExecuteTrxFromAccountDataIterative
@@ -341,9 +334,7 @@ class Indexer:
                                 else:
                                     holder_table[holder_account] = HolderStruct(storage_account)
                             else:
-                                logger.debug("Storage not found")
-                                logger.debug(signature)
-                                logger.debug(storage_account)
+                                logger.debug("LOST_TRX\t{}\t{}".format(signature, storage_account))
 
 
                         elif instruction_data[0] == 0x0c: # Cancel
@@ -377,9 +368,7 @@ class Indexer:
                                 if got_result is not None:
                                     self.submit_transaction(eth_trx, eth_signature, from_address, got_result, [signature])
                                 else:
-                                    logger.debug("Storage not found")
-                                    logger.debug(signature)
-                                    logger.debug(storage_account)
+                                    logger.debug("LOST_TRX\t{}\t{}".format(signature, storage_account))
 
                         elif instruction_data[0] == 0x0d:
                             # logger.debug("{:>10} {:>6} ExecuteTrxFromAccountDataIterativeOrContinue 0x{}".format(slot, counter, instruction_data.hex()))
@@ -402,9 +391,7 @@ class Indexer:
                                     continue_table[storage_account] =  ContinueStruct(signature, got_result)
                                     holder_table[holder_account] = HolderStruct(storage_account)
                                 else:
-                                    logger.debug("Storage not found")
-                                    logger.debug(signature)
-                                    logger.debug(storage_account)
+                                    logger.debug("LOST_TRX\t{}\t{}".format(signature, storage_account))
 
                         if instruction_data[0] > 0x0e:
                             logger.debug("{:>10} {:>6} Unknown 0x{}".format(slot, counter, instruction_data.hex()))

--- a/proxy/indexer/utils.py
+++ b/proxy/indexer/utils.py
@@ -11,8 +11,8 @@ logger.setLevel(logging.DEBUG)
 
 def check_error(trx):
     if 'meta' in trx and 'err' in trx['meta'] and trx['meta']['err'] is not None:
-        logger.debug("Got err trx")
-        logger.debug("\n{}".format(json.dumps(trx['meta']['err'])))
+        # logger.debug("Got err trx")
+        # logger.debug("\n{}".format(json.dumps(trx['meta']['err'])))
         return True
     return False
 
@@ -75,7 +75,7 @@ def get_trx_receipts(unsigned_msg, signature):
     eth_trx[8] = signature[32:64]
 
     eth_trx_raw = rlp.encode(eth_trx)
-    logger.debug(rlp.decode(eth_trx_raw))
+    # logger.debug(rlp.decode(eth_trx_raw))
 
     eth_signature = '0x' + bytes(Web3.keccak(eth_trx_raw)).hex()
     from_address = w3.eth.account.recover_transaction(eth_trx_raw.hex())

--- a/proxy/indexer/utils.py
+++ b/proxy/indexer/utils.py
@@ -1,15 +1,40 @@
 import base58
-import rlp
+import base64
 import json
-import sqlite3
 import logging
-from web3.auto.gethdev import w3
-from ethereum.utils import sha3
-from ethereum.transactions import Transaction
+import os
+import rlp
+import sqlite3
+import subprocess
+from construct import Struct, Bytes, Int64ul
 from eth_utils import big_endian_to_int
+from ethereum.transactions import Transaction as EthTrx
+from ethereum.utils import sha3
+from solana.account import Account
+from solana.publickey import PublicKey
+from solana.rpc.api import Client
+from solana.rpc.commitment import Confirmed
+from solana.rpc.types import TxOpts
+from solana.transaction import AccountMeta, Transaction, TransactionInstruction
+from spl.token.constants import TOKEN_PROGRAM_ID
+from spl.token.instructions import get_associated_token_address
+from web3.auto.gethdev import w3
+
+
+solana_url = os.environ.get("SOLANA_URL", "https://api.devnet.solana.com")
+evm_loader_id = os.environ.get("EVM_LOADER", "eeLSJgWzzxrqKv1UxtRVVH8FX3qCQWUs9QuAjJpETGU")
+ETH_TOKEN_MINT_ID = os.environ.get("ETH_TOKEN_MINT", "89dre8rZjLNft7HoupGiyxu3MNftR577ZYu8bHe2kK7g")
+sysvarclock = "SysvarC1ock11111111111111111111111111111111"
+sysinstruct = "Sysvar1nstructions1111111111111111111111111"
+keccakprog = "KeccakSecp256k11111111111111111111111111111"
+rentid = "SysvarRent111111111111111111111111111111111"
+incinerator = "1nc1nerator11111111111111111111111111111111"
+system = "11111111111111111111111111111111"
+
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
+
 
 def check_error(trx):
     if 'meta' in trx and 'err' in trx['meta'] and trx['meta']['err'] is not None:
@@ -17,6 +42,7 @@ def check_error(trx):
         # logger.debug("\n{}".format(json.dumps(trx['meta']['err'])))
         return True
     return False
+
 
 def get_trx_results(trx):
     slot = trx['slot']
@@ -71,17 +97,69 @@ def get_trx_results(trx):
 
 
 def get_trx_receipts(unsigned_msg, signature):
-    eth_trx = rlp.decode(unsigned_msg, Transaction)
+    trx = rlp.decode(unsigned_msg, EthTrx)
 
-    v = int(signature[64]) + 35 + 2 * eth_trx[6]
+    v = int(signature[64]) + 35 + 2 * trx[6]
     r = big_endian_to_int(signature[0:32])
     s = big_endian_to_int(signature[32:64])
 
-    eth_trx_raw = rlp.encode(Transaction(eth_trx[0], eth_trx[1], eth_trx[2], eth_trx[3], eth_trx[4], eth_trx[5], v, r, s), Transaction)
-    eth_signature = '0x' + sha3(eth_trx_raw).hex()
-    from_address = w3.eth.account.recover_transaction(eth_trx_raw.hex()).lower()
+    trx_raw = rlp.encode(EthTrx(trx[0], trx[1], trx[2], trx[3], trx[4], trx[5], v, r, s), EthTrx)
+    eth_signature = '0x' + sha3(trx_raw).hex()
+    from_address = w3.eth.account.recover_transaction(trx_raw).lower()
 
-    return (eth_trx_raw.hex(), eth_signature, from_address)
+    return (trx_raw.hex(), eth_signature, from_address)
+
+STORAGE_ACCOUNT_INFO_LAYOUT = Struct(
+    # "tag" / Int8ul,
+    "caller" / Bytes(20),
+    "nonce" / Int64ul,
+    "gas_limit" / Int64ul,
+    "gas_price" / Int64ul,
+    "slot" / Int64ul,
+    "operator" / Bytes(32),
+    "accounts_len" / Int64ul,
+    "executor_data_size" / Int64ul,
+    "evm_data_size" / Int64ul,
+)
+
+def get_account_list(client, storage_account):
+    opts = {
+        "encoding": "base64",
+        "commitment": "confirmed",
+        "dataSlice": {
+            "offset": 0,
+            "length": 2048,
+        }
+    }
+    result = client._provider.make_request("getAccountInfo", str(storage_account), opts)
+    # logger.debug("\n{}".format(json.dumps(result, indent=4, sort_keys=True)))
+
+    info = result['result']['value']
+    if info is None:
+        raise Exception("Can't get information about {}".format(storage_account))
+
+    data = base64.b64decode(info['data'][0])
+
+    tag = data[0]
+    if tag == 0:
+        logger.debug("Empty")
+        return None
+    elif tag == 3:
+        logger.debug("Not empty storage")
+
+        acc_list = []
+        storage = STORAGE_ACCOUNT_INFO_LAYOUT.parse(data[1:])
+        offset = 1 + STORAGE_ACCOUNT_INFO_LAYOUT.sizeof()
+        for _ in range(storage.accounts_len):
+            some_pubkey = PublicKey(data[offset:offset + 32])
+            acc_list.append(some_pubkey)
+            offset += 32
+
+        return acc_list
+    else:
+        logger.debug("Not empty other")
+        return None
+
 
 class LogDB:
     def __init__(self, filename="local.db"):
@@ -103,6 +181,7 @@ class LogDB:
         );""")
         self.conn.commit()
 
+
     def push_logs(self, logs):
         rows = []
         for log in logs:
@@ -119,7 +198,7 @@ class LogDB:
                     )
                 )
         if len(rows):
-            logger.debug(rows)
+            # logger.debug(rows)
             cur = self.conn.cursor()
             cur.executemany('INSERT INTO logs VALUES (?, ?, ?, ?,  ?, ?,  ?)', rows)
             self.conn.commit()
@@ -189,3 +268,83 @@ class LogDB:
 
     def __del__(self):
         self.conn.close()
+
+
+class Canceller:
+    def __init__(self):
+        # Initialize user account
+        res = self.call('config', 'get')
+        substr = "Keypair Path: "
+        path = ""
+        for line in res.splitlines():
+            if line.startswith(substr):
+                path = line[len(substr):].strip()
+        if path == "":
+            raise Exception("cannot get keypair path")
+
+        with open(path.strip(), mode='r') as file:
+            pk = (file.read())
+            numbs = list(map(int, pk.strip("[] \n").split(',')))
+            numbs = numbs[0:32]
+            values = bytes(numbs)
+            self.signer = Account(values)
+
+        self.client = Client(solana_url)
+
+        self.operator = self.signer.public_key()
+        self.operator_token = get_associated_token_address(PublicKey(self.operator), PublicKey(ETH_TOKEN_MINT_ID))
+
+
+    def call(self, *args):
+        try:
+            cmd = ["solana",
+                   "--url", solana_url,
+                   ] + list(args)
+            logger.debug(cmd)
+            return subprocess.check_output(cmd, universal_newlines=True)
+        except subprocess.CalledProcessError as err:
+            logger.debug("ERR: solana error {}".format(err))
+            raise
+
+
+    def unlock_accounts(self, blocked_storages):
+        readonly_accs = [
+            PublicKey(evm_loader_id),
+            PublicKey(ETH_TOKEN_MINT_ID),
+            PublicKey(TOKEN_PROGRAM_ID),
+            PublicKey(sysvarclock),
+            PublicKey(sysinstruct),
+            PublicKey(keccakprog),
+            PublicKey(rentid),
+            PublicKey(incinerator),
+            PublicKey(system),
+        ]
+        for storage in blocked_storages:
+            acc_list = get_account_list(self.client, storage)
+            if acc_list is not None:
+                keys = [
+                        AccountMeta(pubkey=storage, is_signer=False, is_writable=True),
+                        AccountMeta(pubkey=self.operator, is_signer=True, is_writable=True),
+                        AccountMeta(pubkey=self.operator_token, is_signer=False, is_writable=True),
+                        AccountMeta(pubkey=acc_list[1], is_signer=False, is_writable=True),
+                        AccountMeta(pubkey=incinerator, is_signer=False, is_writable=True),
+                        AccountMeta(pubkey=system, is_signer=False, is_writable=False)
+                    ]
+                for acc in acc_list:
+                    keys.append(AccountMeta(pubkey=acc, is_signer=False, is_writable=(False if acc in readonly_accs else True)))
+
+                trx = Transaction()
+                trx.add(TransactionInstruction(
+                    program_id=evm_loader_id,
+                    data=bytearray.fromhex("0C"),
+                    keys=keys
+                ))
+
+                logger.debug("Send Cancel")
+                try:
+                    self.client.send_transaction(trx, self.signer, opts=TxOpts(preflight_commitment=Confirmed))
+                except Exception as err:
+                    logger.debug(err)
+                else:
+                    logger.debug("Canceled")
+                    logger.debug(acc_list)

--- a/proxy/indexer/utils.py
+++ b/proxy/indexer/utils.py
@@ -326,7 +326,7 @@ class Canceller:
                         AccountMeta(pubkey=storage, is_signer=False, is_writable=True),
                         AccountMeta(pubkey=self.operator, is_signer=True, is_writable=True),
                         AccountMeta(pubkey=self.operator_token, is_signer=False, is_writable=True),
-                        AccountMeta(pubkey=acc_list[1], is_signer=False, is_writable=True),
+                        AccountMeta(pubkey=acc_list[4], is_signer=False, is_writable=True),
                         AccountMeta(pubkey=incinerator, is_signer=False, is_writable=True),
                         AccountMeta(pubkey=system, is_signer=False, is_writable=False)
                     ]

--- a/proxy/indexer/utils.py
+++ b/proxy/indexer/utils.py
@@ -1,10 +1,10 @@
 import base58
 import rlp
-import json
-import time
 import logging
-from web3 import Web3
 from web3.auto.gethdev import w3
+from ethereum.utils import sha3
+from ethereum.transactions import Transaction
+from eth_utils import big_endian_to_int
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -68,16 +68,14 @@ def get_trx_results(trx):
 
 
 def get_trx_receipts(unsigned_msg, signature):
-    eth_trx = rlp.decode(unsigned_msg)
+    eth_trx = rlp.decode(unsigned_msg, Transaction)
 
-    eth_trx[6] = int(signature[64]) + 35 + 2 * int.from_bytes(eth_trx[6], "little")
-    eth_trx[7] = signature[:32]
-    eth_trx[8] = signature[32:64]
+    v = int(signature[64]) + 35 + 2 * eth_trx[6]
+    r = big_endian_to_int(signature[0:32])
+    s = big_endian_to_int(signature[32:64])
 
-    eth_trx_raw = rlp.encode(eth_trx)
-    # logger.debug(rlp.decode(eth_trx_raw))
-
-    eth_signature = '0x' + bytes(Web3.keccak(eth_trx_raw)).hex()
-    from_address = w3.eth.account.recover_transaction(eth_trx_raw.hex())
+    eth_trx_raw = rlp.encode(Transaction(eth_trx[0], eth_trx[1], eth_trx[2], eth_trx[3], eth_trx[4], eth_trx[5], v, r, s), Transaction)
+    eth_signature = '0x' + sha3(eth_trx_raw).hex()
+    from_address = w3.eth.account.recover_transaction(eth_trx_raw.hex()).lower()
 
     return (eth_trx_raw.hex(), eth_signature, from_address)

--- a/proxy/plugin/solana_rest_api.py
+++ b/proxy/plugin/solana_rest_api.py
@@ -315,7 +315,7 @@ class EthereumModel:
             "from": trx_info['from_address'],
             "to": addr_to,
             "gasUsed": hex(trx_info['gas_used']),
-            "cumulativeGasUsed": '0x%x' % trx_info['gas_used'],
+            "cumulativeGasUsed": hex(trx_info['gas_used']),
             "contractAddress": contract,
             "logs": logs,
             "status": trx_info['status'],

--- a/proxy/test_cancel_hanged.py
+++ b/proxy/test_cancel_hanged.py
@@ -1,0 +1,241 @@
+import os
+import sys
+
+sys.path.append("/spl/bin/")
+os.environ['SOLANA_URL'] = "http://solana:8899"
+os.environ['EVM_LOADER'] = "53DfF883gyixYNXnM7s5xhdeyV8mVk9T4i2hGV9vG9io"
+os.environ['ETH_TOKEN_MINT'] = "HPsV9Deocecw3GeZv1FkAPNCBRfuVyfw9MMwjwRe1xaU"
+os.environ['COLLATERAL_POOL_BASE'] = "4sW3SZDJB7qXUyCYKA7pFL8eCTfm3REr8oSiKkww7MaT"
+os.environ['NEON_CHAIN_ID'] = "0x6f"
+
+import base64
+import unittest
+import rlp
+from eth_tx_utils import make_instruction_data_from_tx, make_keccak_instruction_data
+from eth_utils import big_endian_to_int
+from ethereum.transactions import Transaction as EthTrx
+from ethereum.utils import sha3
+from solana.publickey import PublicKey
+from solana.rpc.commitment import Confirmed
+from solana.transaction import AccountMeta, Transaction, TransactionInstruction
+from solana_utils import *
+from solcx import install_solc
+from spl.token.constants import TOKEN_PROGRAM_ID
+from spl.token.instructions import get_associated_token_address
+from web3 import Web3
+from web3.auto.gethdev import w3
+
+# install_solc(version='latest')
+install_solc(version='0.7.0')
+from solcx import compile_source
+
+SEED = 'https://github.com/neonlabsorg/proxy-model.py/issues/196'
+proxy_url = os.environ.get('PROXY_URL', 'http://localhost:9090/solana')
+proxy = Web3(Web3.HTTPProvider(proxy_url))
+eth_account = proxy.eth.account.create(SEED)
+proxy.eth.default_account = eth_account.address
+
+ACCOUNT_SEED_VERSION=b'\1'
+
+TEST_EVENT_SOURCE_196 = '''
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.5.12;
+
+contract ReturnsEvents {
+    event Added(uint8 sum);
+
+    function addNoReturn(uint8 x, uint8 y) public {
+        x + y;
+    }
+
+    function addReturn(uint8 x, uint8 y) public returns(uint8) {
+        return x + y;
+    }
+
+    function addReturnEvent(uint8 x, uint8 y) public returns(uint8) {
+        uint8 sum =x+y;
+
+        emit Added(sum);
+        return sum;
+    }
+
+    function addReturnEventTwice(uint8 x, uint8 y) public returns(uint8) {
+        uint8 sum = x + y;
+        emit Added(sum);
+        sum += y;
+        emit Added(sum);
+        return sum;
+    }
+}
+'''
+
+
+class CancelTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        print("\ntest_event.py setUpClass")
+
+        cls.token = SplToken(solana_url)
+        wallet = WalletAccount(wallet_path())
+        cls.loader = EvmLoader(wallet, EVM_LOADER)
+        cls.acc = wallet.get_acc()
+
+        cls.deploy_contract(cls)
+
+        print(cls.storage_contract.address)
+
+        cls.reId_eth = cls.storage_contract.address.lower()
+        print ('contract_eth', cls.reId_eth)
+        (cls.reId, cls.reId_token, cls.re_code) = cls.get_accounts(cls, cls.reId_eth)
+        print ('contract', cls.reId)
+        print ('contract_code', cls.re_code)
+
+        proxy.eth.default_account
+        # Create ethereum account for user account
+        cls.caller_ether = proxy.eth.default_account.lower()
+        (cls.caller, cls.caller_token, _) = cls.get_accounts(cls, cls.caller_ether)
+        print ('caller_ether', cls.caller_ether)
+        print ('caller', cls.caller)
+
+        if getBalance(cls.caller) == 0:
+            print("Create caller account...")
+            _ = cls.loader.createEtherAccount(cls.caller_ether)
+            print("Done\n")
+        # cls.token.transfer(ETH_TOKEN_MINT_ID, 2000, cls.caller_token)
+
+        collateral_pool_index = 2
+        cls.collateral_pool_address = create_collateral_pool_address(collateral_pool_index)
+        cls.collateral_pool_index_buf = collateral_pool_index.to_bytes(4, 'little')
+
+        cls.create_hanged_transaction(cls)
+
+    def get_accounts(self, ether):
+        (sol_address, _) = self.loader.ether2program(ether)
+        info = client.get_account_info(sol_address, commitment=Confirmed)['result']['value']
+        data = base64.b64decode(info['data'][0])
+        acc_info = ACCOUNT_INFO_LAYOUT.parse(data)
+
+        code_address = PublicKey(acc_info.code_acc)
+        alternate_token = get_associated_token_address(PublicKey(sol_address), ETH_TOKEN_MINT_ID)
+
+        return (sol_address, alternate_token, code_address)
+
+    def deploy_contract(self):
+        compiled_sol = compile_source(TEST_EVENT_SOURCE_196)
+        contract_id, contract_interface = compiled_sol.popitem()
+        storage = proxy.eth.contract(abi=contract_interface['abi'], bytecode=contract_interface['bin'])
+        trx_deploy = proxy.eth.account.sign_transaction(dict(
+            nonce=proxy.eth.get_transaction_count(proxy.eth.default_account),
+            chainId=proxy.eth.chain_id,
+            gas=987654321,
+            gasPrice=0,
+            to='',
+            value=0,
+            data=storage.bytecode),
+            eth_account.key
+        )
+        trx_deploy_hash = proxy.eth.send_raw_transaction(trx_deploy.rawTransaction)
+        print('trx_deploy_hash:', trx_deploy_hash.hex())
+        trx_deploy_receipt = proxy.eth.wait_for_transaction_receipt(trx_deploy_hash)
+        print('trx_deploy_receipt:', trx_deploy_receipt)
+
+        self.storage_contract = proxy.eth.contract(
+            address=trx_deploy_receipt.contractAddress,
+            abi=storage.abi
+        )
+
+    def create_hanged_transaction(self):
+        print("\ncommit_two_event_trx")
+        right_nonce = proxy.eth.get_transaction_count(proxy.eth.default_account)
+        trx_store = self.storage_contract.functions.addReturnEventTwice(1, 1).buildTransaction({'nonce': right_nonce})
+        trx_store_signed = proxy.eth.account.sign_transaction(trx_store, eth_account.key)
+
+        (from_addr, sign, msg) = make_instruction_data_from_tx(trx_store_signed.rawTransaction.hex())
+        instruction = from_addr + sign + msg
+
+        (trx_raw, self.tx_hash, from_address) = self.get_trx_receipts(self, msg, sign)
+        print(self.tx_hash)
+        print(from_address)
+
+        self.storage = self.create_storage_account(self, sign[:8].hex())
+        print("storage", self.storage)
+        self.call_begin(self, self.storage, 10, msg, instruction)
+
+    def get_trx_receipts(self, unsigned_msg, signature):
+        trx = rlp.decode(unsigned_msg, EthTrx)
+
+        v = int(signature[64]) + 35 + 2 * trx[6]
+        r = big_endian_to_int(signature[0:32])
+        s = big_endian_to_int(signature[32:64])
+
+        trx_raw = rlp.encode(EthTrx(trx[0], trx[1], trx[2], trx[3], trx[4], trx[5], v, r, s), EthTrx)
+        eth_signature = '0x' + sha3(trx_raw).hex()
+        from_address = w3.eth.account.recover_transaction(trx_raw).lower()
+
+        return (trx_raw.hex(), eth_signature, from_address)
+
+
+    def sol_instr_09_partial_call(self, storage_account, step_count, evm_instruction):
+        return TransactionInstruction(
+            program_id=self.loader.loader_id,
+            data=bytearray.fromhex("09") + self.collateral_pool_index_buf + step_count.to_bytes(8, byteorder='little') + evm_instruction,
+            keys=[
+                AccountMeta(pubkey=storage_account, is_signer=False, is_writable=True),
+
+                # System instructions account:
+                AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
+                # Operator address:
+                AccountMeta(pubkey=self.acc.public_key(), is_signer=True, is_writable=True),
+                # Collateral pool address:
+                AccountMeta(pubkey=self.collateral_pool_address, is_signer=False, is_writable=True),
+                # System program account:
+                AccountMeta(pubkey=PublicKey(system), is_signer=False, is_writable=False),
+
+                AccountMeta(pubkey=self.reId, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=self.reId_token, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=self.re_code, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=self.caller, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=self.caller_token, is_signer=False, is_writable=True),
+
+                AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
+                AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
+                AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
+            ])
+
+
+    def call_begin(self, storage, steps, msg, instruction):
+        print("Begin")
+        trx = Transaction()
+        trx.add(self.sol_instr_keccak(self, make_keccak_instruction_data(1, len(msg), 13)))
+        trx.add(self.sol_instr_09_partial_call(self, storage, steps, instruction))
+        print(trx.__dict__)
+        return send_transaction(client, trx, self.acc)
+
+
+    def sol_instr_keccak(self, keccak_instruction):
+        return TransactionInstruction(program_id=keccakprog, data=keccak_instruction, keys=[
+                AccountMeta(pubkey=PublicKey(keccakprog), is_signer=False, is_writable=False), ])
+
+
+    def create_storage_account(self, seed):
+        storage = PublicKey(sha256(bytes(self.acc.public_key()) + bytes(seed, 'utf8') + bytes(PublicKey(EVM_LOADER))).digest())
+        print("Storage", storage)
+
+        if getBalance(storage) == 0:
+            trx = Transaction()
+            trx.add(createAccountWithSeed(self.acc.public_key(), self.acc.public_key(), seed, 10**9, 128*1024, PublicKey(EVM_LOADER)))
+            send_transaction(client, trx, self.acc)
+
+        return storage
+
+
+    def test_canceled(self):
+        print("\ntest_canceled")
+        trx_receipt = proxy.eth.wait_for_transaction_receipt(self.tx_hash)
+        print('trx_receipt:', trx_receipt)
+        self.assertEqual(trx_receipt['status'], 0)
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,9 @@ typing-extensions==3.7.4.2
 ecdsa==0.16.0
 pysha3==1.0.2
 eth-keys==0.3.3
-rlp==2.0.1
+rlp
 web3==5.22.0
 solana==0.10.0
 sqlitedict
+ethereum
 py-solc-x==1.1.0


### PR DESCRIPTION
While indexing transactions remembering storages of possibly hanged transactions.
For found hanged transactions check slot difference - it must be more than `OPERATOR_PRIORITY_SLOTS` (16).
Then check storage for emptiness by parsing its account data. 
Extract blocked accounts list from the storage account, make and send cancel instruction.

Added a new structure to help operate canceling transactions.

There could be false-positive results on hanged transactions because of no guarantees of ordering in block from Solana.