### PR TITLE
#239 Fix looping when not able to get result from transaction

### DIFF
--- a/proxy/plugin/solana_rest_api_tools.py
+++ b/proxy/plugin/solana_rest_api_tools.py
@@ -452,12 +452,22 @@ def check_if_program_exceeded_instructions(err_result):
 
 
 def check_if_continue_returned(result):
-    for inner in (result['result']['meta']['innerInstructions']):
-        for event in inner['instructions']:
-            log = base58.b58decode(event['data'])
-            instruction = log[:1]
-            if int().from_bytes(instruction, "little") == 6:  # OnReturn evmInstruction code
-                return (True, result['result']['transaction']['signatures'][0])
+    tx_info = result['result']
+    accounts = tx_info["transaction"]["message"]["accountKeys"]
+    evm_loader_instructions = []
+
+    for idx, trx in enumerate(tx_info["transaction"]["message"]["instructions"]):
+        if accounts[trx["programIdIndex"]] == evm_loader_id:
+            evm_loader_instructions.append(idx)
+
+    for inner in (tx_info['meta']['innerInstructions']):
+        if inner["index"] in evm_loader_instructions:
+            for event in inner['instructions']:
+                if accounts[event['programIdIndex']] == evm_loader_id:
+                    instruction = base58.b58decode(event['data'])[:1]
+                    if int().from_bytes(instruction, "little") == 6:  # OnReturn evmInstruction code
+                        logger.debug("Result:\n%s"%json.dumps(result, indent=3))
+                        return (True, tx_info['transaction']['signatures'][0])
     return (False, ())
 
 

--- a/proxy/plugin/solana_rest_api_tools.py
+++ b/proxy/plugin/solana_rest_api_tools.py
@@ -456,8 +456,8 @@ def check_if_continue_returned(result):
     accounts = tx_info["transaction"]["message"]["accountKeys"]
     evm_loader_instructions = []
 
-    for idx, trx in enumerate(tx_info["transaction"]["message"]["instructions"]):
-        if accounts[trx["programIdIndex"]] == evm_loader_id:
+    for idx, instruction in enumerate(tx_info["transaction"]["message"]["instructions"]):
+        if accounts[instruction["programIdIndex"]] == evm_loader_id:
             evm_loader_instructions.append(idx)
 
     for inner in (tx_info['meta']['innerInstructions']):
@@ -466,7 +466,6 @@ def check_if_continue_returned(result):
                 if accounts[event['programIdIndex']] == evm_loader_id:
                     instruction = base58.b58decode(event['data'])[:1]
                     if int().from_bytes(instruction, "little") == 6:  # OnReturn evmInstruction code
-                        logger.debug("Result:\n%s"%json.dumps(result, indent=3))
                         return (True, tx_info['transaction']['signatures'][0])
     return (False, ())
 

--- a/proxy/plugin/solana_rest_api_tools.py
+++ b/proxy/plugin/solana_rest_api_tools.py
@@ -1,3 +1,4 @@
+import base58
 import base64
 import json
 import logging
@@ -451,16 +452,11 @@ def check_if_program_exceeded_instructions(err_result):
 
 
 def check_if_continue_returned(result):
-    acc_meta_lst = result["result"]["transaction"]["message"]["accountKeys"]
-    evm_loader_index = acc_meta_lst.index(evm_loader_id)
-
-    innerInstruction = result['result']['meta']['innerInstructions']
-    innerInstruction = next((i for i in innerInstruction if i["index"] == 0), None)
-    if (innerInstruction and innerInstruction['instructions']):
-        instruction = innerInstruction['instructions'][-1]
-        if (instruction['programIdIndex'] == evm_loader_index):
-            data = b58decode(instruction['data'])
-            if (data[0] == 6):
+    for inner in (result['result']['meta']['innerInstructions']):
+        for event in inner['instructions']:
+            log = base58.b58decode(event['data'])
+            instruction = log[:1]
+            if int().from_bytes(instruction, "little") == 6:  # OnReturn evmInstruction code
                 return (True, result['result']['transaction']['signatures'][0])
     return (False, ())
 
@@ -519,7 +515,7 @@ def call_continue_bucked(signer, client, perm_accs, trx_accs, steps):
             else:
                 raise
 
-        logger.debug("Collect bucked results:")
+        logger.debug("Collect bucked results: {}".format(result_list))
         for trx in result_list:
             confirm_transaction(client, trx)
             result = client.get_confirmed_transaction(trx)


### PR DESCRIPTION
Rewritten search for results in a transaction by searching of inner transaction in loop besides of search by index. And added checks for instruction ownership.