### PR TITLE
#241 Iterations from emulator

### DIFF
--- a/.buildkite/steps/build-image.sh
+++ b/.buildkite/steps/build-image.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 REVISION=$(git rev-parse HEAD)
 
-set ${SOLANA_REVISION:=v1.7.9-resources}
-set ${EVM_LOADER_REVISION:=latest}
+set ${SOLANA_REVISION:=v1.7.9-testnet}
+set ${EVM_LOADER_REVISION:=ca4df414d0dc2e45d80044516dacef8ef5000e24}
 
 # Refreshing neonlabsorg/solana:latest image is required to run .buildkite/steps/build-image.sh locally
 docker pull neonlabsorg/solana:${SOLANA_REVISION}

--- a/.buildkite/steps/build-image.sh
+++ b/.buildkite/steps/build-image.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 REVISION=$(git rev-parse HEAD)
 
 set ${SOLANA_REVISION:=v1.7.9-testnet}
-set ${EVM_LOADER_REVISION:=ca4df414d0dc2e45d80044516dacef8ef5000e24}
+set ${EVM_LOADER_REVISION:=latest}
 
 # Refreshing neonlabsorg/solana:latest image is required to run .buildkite/steps/build-image.sh locally
 docker pull neonlabsorg/solana:${SOLANA_REVISION}

--- a/proxy/docker-compose-test.yml
+++ b/proxy/docker-compose-test.yml
@@ -3,7 +3,7 @@ version: "2.1"
 services:
   solana:
     container_name: solana
-    image: neonlabsorg/solana:${SOLANA_REVISION:-v1.7.9-resources}
+    image: neonlabsorg/solana:${SOLANA_REVISION:-v1.7.9-testnet}
     environment:
       - SOLANA_URL=http://solana:8899
       - RUST_LOG=solana_runtime::system_instruction_processor=trace,solana_runtime::message_processor=debug,solana_bpf_loader=debug,solana_rbpf=debug

--- a/proxy/indexer/solana_receipts_update.py
+++ b/proxy/indexer/solana_receipts_update.py
@@ -369,11 +369,15 @@ class Indexer:
                                 trx_table[eth_signature].signatures = continue_result.signatures
                                 del continue_table[storage_account]
 
-                        elif instruction_data[0] == 0x0a: # Continue
-                            # logger.debug("{:>10} {:>6} Continue 0x{}".format(slot, counter, instruction_data.hex()))
+                        elif instruction_data[0] == 0x0a or instruction_data[0] == 0x14: # Continue or ContinueV02
 
                             storage_account = trx['transaction']['message']['accountKeys'][instruction['accounts'][0]]
-                            blocked_accounts = [trx['transaction']['message']['accountKeys'][acc_idx] for acc_idx in instruction['accounts'][5:]]
+                            if instruction_data[0] == 0x0a:
+                                # logger.debug("{:>10} {:>6} Continue 0x{}".format(slot, counter, instruction_data.hex()))
+                                blocked_accounts = [trx['transaction']['message']['accountKeys'][acc_idx] for acc_idx in instruction['accounts'][5:]]
+                            if instruction_data[0] == 0x14:
+                                # logger.debug("{:>10} {:>6} ContinueV02 0x{}".format(slot, counter, instruction_data.hex()))
+                                blocked_accounts = [trx['transaction']['message']['accountKeys'][acc_idx] for acc_idx in instruction['accounts'][5:]]
                             got_result = get_trx_results(trx)
 
                             if storage_account in continue_table:
@@ -406,7 +410,9 @@ class Indexer:
                                 continue_table[storage_account].signatures.append(signature)
 
                                 if holder_account in holder_table:
-                                    holder_table[holder_account] = HolderStruct(storage_account)
+                                    if holder_table[holder_account].storage_account != storage_account:
+                                        logger.error("Strange behavior. Pay attention. STORAGE_ACCOUNT != STORAGE_ACCOUNT")
+                                        holder_table[holder_account] = HolderStruct(storage_account)
                                 else:
                                     holder_table[holder_account] = HolderStruct(storage_account)
                             else:
@@ -454,9 +460,11 @@ class Indexer:
                                 continue_table[storage_account].signatures.append(signature)
 
                                 if holder_account in holder_table:
-                                    logger.error("Strange behavior. Pay attention. HOLDER ACCOUNT FOUND")
-                                    holder_table[holder_account] = HolderStruct(storage_account)
+                                    if holder_table[holder_account].storage_account != storage_account:
+                                        logger.error("Strange behavior. Pay attention. STORAGE_ACCOUNT != STORAGE_ACCOUNT")
+                                        holder_table[holder_account] = HolderStruct(storage_account)
                                 else:
+                                    logger.error("Strange behavior. Pay attention. HOLDER ACCOUNT NOT FOUND")
                                     holder_table[holder_account] = HolderStruct(storage_account)
 
                                 if got_result:
@@ -467,67 +475,8 @@ class Indexer:
 
                                     continue_table[storage_account].results = got_result
                             else:
-                                got_result = get_trx_results(trx)
-                                if got_result is not None:
-                                    continue_table[storage_account] =  ContinueStruct(signature, got_result, blocked_accounts)
-                                    holder_table[holder_account] = HolderStruct(storage_account)
-                                else:
-                                    self.add_hunged_storage(trx, storage_account)
-
-                        elif instruction_data[0] == 0x13:  # PartialCallFromRawEthereumTXv02
-                            # logger.debug("{:>10} {:>6} PartialCallFromRawEthereumTXv02 0x{}".format(slot, counter, instruction_data.hex()))
-
-                            storage_account = trx['transaction']['message']['accountKeys'][instruction['accounts'][0]]
-
-                            if storage_account in continue_table:
-                                # collateral_pool_buf = instruction_data[1:5]
-                                # step_count = instruction_data[5:13]
-                                # from_addr = instruction_data[13:33]
-
-                                sign = instruction_data[33:98]
-                                unsigned_msg = instruction_data[98:]
-
-                                (eth_trx, eth_signature, from_address) = get_trx_receipts(unsigned_msg, sign)
-
-                                continue_result = continue_table[storage_account]
-
-                                self.submit_transaction(eth_trx, eth_signature, from_address, continue_result.results, continue_result.signatures)
-
-                                del continue_table[storage_account]
-                            else:
-                                self.add_hunged_storage(trx, storage_account)
-
-                        elif instruction_data[0] == 0x14:  # ContinueV02
-                            # logger.debug("{:>10} {:>6} ContinueV02 0x{}".format(slot, counter, instruction_data.hex()))
-
-                            storage_account = trx['transaction']['message']['accountKeys'][instruction['accounts'][0]]
-
-                            if storage_account in continue_table:
-                                continue_table[storage_account].signatures.append(signature)
-                            else:
-                                got_result = get_trx_results(trx)
-                                if got_result is not None:
-                                    continue_table[storage_account] = ContinueStruct(signature, got_result)
-                                else:
-                                    self.add_hunged_storage(trx, storage_account)
-
-                        elif instruction_data[0] == 0x16:  # ExecuteTrxFromAccountDataIterativeV02
-                            # logger.debug("{:>10} {:>6} ExecuteTrxFromAccountDataIterativeV02 0x{}".format(slot, counter, instruction_data.hex()))
-
-                            holder_account =  trx['transaction']['message']['accountKeys'][instruction['accounts'][0]]
-                            storage_account = trx['transaction']['message']['accountKeys'][instruction['accounts'][1]]
-
-                            if storage_account in continue_table:
-                                continue_table[storage_account].signatures.append(signature)
-
-                                if holder_account in holder_table:
-                                    # logger.debug("holder_account found")
-                                    # logger.debug("Strange behavior. Pay attention.")
-                                    holder_table[holder_account] = HolderStruct(storage_account)
-                                else:
-                                    holder_table[holder_account] = HolderStruct(storage_account)
-                            else:
-                                self.add_hunged_storage(trx, storage_account)
+                                continue_table[storage_account] =  ContinueStruct(signature, got_result, blocked_accounts)
+                                holder_table[holder_account] = HolderStruct(storage_account)
 
                         if instruction_data[0] > 0x16:
                             logger.debug("{:>10} {:>6} Unknown 0x{}".format(slot, counter, instruction_data.hex()))

--- a/proxy/indexer/solana_receipts_update.py
+++ b/proxy/indexer/solana_receipts_update.py
@@ -554,11 +554,6 @@ class Indexer:
         return (slot, block_hash)
 
 
-    def add_hunged_storage(self, trx, storage):
-        if abs(trx['slot'] - self.current_slot) > 16:
-            self.blocked_storages.add(storage)
-
-
 def run_indexer():
     logging.basicConfig(format='%(asctime)s - pid:%(process)d [%(levelname)-.1s] %(funcName)s:%(lineno)d - %(message)s')
     logger.setLevel(logging.DEBUG)

--- a/proxy/plugin/solana_rest_api_tools.py
+++ b/proxy/plugin/solana_rest_api_tools.py
@@ -537,6 +537,8 @@ def call_continue_bucked(signer, client, perm_accs, trx_accs, steps_emulated, st
     except Exception as err:
         if str(err).startswith("Transaction simulation failed: Error processing Instruction 0: custom program error: 0x1"):
             pass
+        elif check_if_program_exceeded_instructions(err.result):
+            steps = int(steps * 90 / 100)
         else:
             raise
 
@@ -573,6 +575,8 @@ def call_continue_bucked_0x0d(signer, client, ethTrx, perm_accs, trx_accs, steps
     except Exception as err:
         if str(err).startswith("Transaction simulation failed: Error processing Instruction 0: custom program error: 0x1"):
             pass
+        elif check_if_program_exceeded_instructions(err.result):
+            steps = int(steps * 90 / 100)
         else:
             raise
 
@@ -602,6 +606,8 @@ def call_continue_bucked_0x0e(signer, client, perm_accs, trx_accs, steps_emulate
     except Exception as err:
         if str(err).startswith("Transaction simulation failed: Error processing Instruction 0: custom program error: 0x1"):
             pass
+        elif check_if_program_exceeded_instructions(err.result):
+            steps = int(steps * 90 / 100)
         else:
             raise
 

--- a/proxy/plugin/solana_rest_api_tools.py
+++ b/proxy/plugin/solana_rest_api_tools.py
@@ -476,10 +476,13 @@ def check_if_continue_returned(result):
 
 def call_continue_combined(signer, client, ethTrx, perm_accs, trx_accs, steps_emulated, steps, msg):
     try:
-        return call_continue_bucked_0x0d(signer, client, ethTrx, perm_accs, trx_accs, steps_emulated, steps, msg)
+        return_result = call_continue_bucked_0x0d(signer, client, ethTrx, perm_accs, trx_accs, steps_emulated, steps, msg)
     except Exception as err:
         logger.debug("call_continue_bucked_0x0D exception:")
         logger.debug(str(err))
+
+    if return_result is not None:
+        return return_result
 
     try:
         return call_continue_iterative(signer, client, perm_accs, trx_accs, steps)
@@ -492,10 +495,13 @@ def call_continue_combined(signer, client, ethTrx, perm_accs, trx_accs, steps_em
 
 def call_continue_with_holder_combined(signer, client, perm_accs, trx_accs, steps_emulated, steps):
     try:
-        return call_continue_bucked_0x0e(signer, client, perm_accs, trx_accs, steps_emulated, steps)
+        return_result = call_continue_bucked_0x0e(signer, client, perm_accs, trx_accs, steps_emulated, steps)
     except Exception as err:
         logger.debug("call_continue_bucked_0x0E exception:")
         logger.debug(str(err))
+
+    if return_result is not None:
+        return return_result
 
     try:
         return call_continue_iterative(signer, client, perm_accs, trx_accs, steps)
@@ -508,10 +514,13 @@ def call_continue_with_holder_combined(signer, client, perm_accs, trx_accs, step
 
 def call_continue(signer, client, perm_accs, trx_accs, steps_emulated, steps):
     try:
-        return call_continue_bucked(signer, client, perm_accs, trx_accs, steps_emulated, steps)
+        return_result = call_continue_bucked(signer, client, perm_accs, trx_accs, steps_emulated, steps)
     except Exception as err:
         logger.debug("call_continue_bucked exception:")
         logger.debug(str(err))
+
+    if return_result is not None:
+        return return_result
 
     try:
         return call_continue_iterative(signer, client, perm_accs, trx_accs, steps)


### PR DESCRIPTION
Use steps from the emulator to calculate the count of Solana transactions needed for Ethereum transaction execution.
PR adds instructions for combined execution transactions from the holder account.
Use different steps instead of indexes in combined instruction because of  neonlabsorg/neon-evm#351 

Indexer fixes:
Added timeout to cancel hanged transactions.
Fixed problems caused by merges in other PR's.