### PR TITLE
#272 Manage transaction accounts (storage, holder, collateral pool)

### DIFF
--- a/proxy/core/acceptor/pool.py
+++ b/proxy/core/acceptor/pool.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 LOCK = multiprocessing.Lock()
 
 proxy_id_glob = multiprocessing.Value('i', 0)
+proxy_used_id_glob = multiprocessing.Array('i', 1024)
 
 
 class AcceptorPool:


### PR DESCRIPTION
Changes:
 - add a multiprocessing array to manage used indexes. If used, set 1 - 0 on freeing.
 - create `PermanentAccounts` object on `eth_sendRawTransaction` call instead of worker constructor.