### PR TITLE
#333 fix indexer errors

### DIFF
--- a/proxy/indexer/solana_receipts_update.py
+++ b/proxy/indexer/solana_receipts_update.py
@@ -286,8 +286,8 @@ class Indexer:
                                         # logger.debug("rlp.exceptions.RLPException")
                                         pass
                                     except Exception as err:
-                                        if str(err).startswith("unhashable type"):
-                                            # logger.debug("unhashable type")
+                                        if str(err).startswith("nonhashable type"):
+                                            # logger.debug("nonhashable type")
                                             pass
                                         elif str(err).startswith("unsupported operand type"):
                                             # logger.debug("unsupported operand type")
@@ -413,10 +413,8 @@ class Indexer:
                                 # logger.debug("{:>10} {:>6} ExecuteTrxFromAccountDataIterativeV02 0x{}".format(slot, counter, instruction_data.hex()))
                                 blocked_accounts = [trx['transaction']['message']['accountKeys'][acc_idx] for acc_idx in instruction['accounts'][7:]]
 
-
                             holder_account =  trx['transaction']['message']['accountKeys'][instruction['accounts'][0]]
                             storage_account = trx['transaction']['message']['accountKeys'][instruction['accounts'][1]]
-                            blocked_accounts = [trx['transaction']['message']['accountKeys'][acc_idx] for acc_idx in instruction['accounts'][5:]]
 
                             if storage_account in continue_table:
                                 continue_table[storage_account].signatures.append(signature)
@@ -514,10 +512,13 @@ class Indexer:
                             pass
 
         for eth_signature, trx_struct in trx_table.items():
-            if trx_struct.got_result:
+            if trx_struct.got_result is not None:
                 self.submit_transaction(trx_struct)
-            elif trx_struct.storage:
+            elif trx_struct.storage is not None:
                 if abs(trx_struct.slot - self.current_slot) > CANCEL_TIMEOUT:
+                    logger.debug("Probably blocked")
+                    logger.debug(trx_struct.eth_signature)
+                    logger.debug(trx_struct.signatures)
                     self.blocked_storages[trx_struct.storage] = (trx_struct.eth_trx, trx_struct.blocked_accounts)
             else:
                 logger.error(trx_struct)

--- a/proxy/indexer/solana_receipts_update.py
+++ b/proxy/indexer/solana_receipts_update.py
@@ -389,7 +389,7 @@ class Indexer:
                                 blocked_accounts = [trx['transaction']['message']['accountKeys'][acc_idx] for acc_idx in instruction['accounts'][5:]]
                             if instruction_data[0] == 0x14:
                                 # logger.debug("{:>10} {:>6} ContinueV02 0x{}".format(slot, counter, instruction_data.hex()))
-                                blocked_accounts = [trx['transaction']['message']['accountKeys'][acc_idx] for acc_idx in instruction['accounts'][5:]]
+                                blocked_accounts = [trx['transaction']['message']['accountKeys'][acc_idx] for acc_idx in instruction['accounts'][6:]]
                             got_result = get_trx_results(trx)
 
                             if storage_account in continue_table:

--- a/proxy/indexer/utils.py
+++ b/proxy/indexer/utils.py
@@ -350,6 +350,10 @@ class Canceller:
             if blocked_accs is None:
                 logger.error("blocked_accs is None")
                 continue
+            if acc_list is None:
+                logger.error("acc_list is None. Storage is empty")
+                logger.error(storage)
+                continue
 
             eth_trx = rlp.decode(bytes.fromhex(eth_trx), EthTrx)
             if acc_list != blocked_accs:

--- a/proxy/plugin/solana_rest_api.py
+++ b/proxy/plugin/solana_rest_api.py
@@ -55,6 +55,7 @@ class EthereumModel:
         self.logs_db = LogDB()
         self.blocks_by_hash = SQLDict(tablename="solana_blocks_by_hash")
         self.ethereum_trx = SQLDict(tablename="ethereum_transactions")
+        self.eth_sol_trx = SQLDict(tablename="ethereum_solana_transactions")
         self.sol_eth_trx = SQLDict(tablename="solana_ethereum_transactions")
 
         with proxy_id_glob.get_lock():
@@ -458,7 +459,12 @@ class EthereumModel:
                         'return_value': None,
                         'from_address': '0x'+sender,
                     }
+                self.eth_sol_trx[eth_signature] = [signature]
                 self.blocks_by_hash[block_hash] = slot
+                self.sol_eth_trx[signature] = {
+                    'idx': 0,
+                    'eth': eth_signature,
+                }
             except Exception as err:
                 logger.debug(err)
 

--- a/proxy/plugin/solana_rest_api.py
+++ b/proxy/plugin/solana_rest_api.py
@@ -55,7 +55,6 @@ class EthereumModel:
         self.logs_db = LogDB()
         self.blocks_by_hash = SQLDict(tablename="solana_blocks_by_hash")
         self.ethereum_trx = SQLDict(tablename="ethereum_transactions")
-        self.eth_sol_trx = SQLDict(tablename="ethereum_solana_transactions")
         self.sol_eth_trx = SQLDict(tablename="solana_ethereum_transactions")
 
         with proxy_id_glob.get_lock():
@@ -459,12 +458,7 @@ class EthereumModel:
                         'return_value': None,
                         'from_address': '0x'+sender,
                     }
-                self.eth_sol_trx[eth_signature] = [signature]
                 self.blocks_by_hash[block_hash] = slot
-                self.sol_eth_trx[signature] = {
-                    'idx': 0,
-                    'eth': eth_signature,
-                }
             except Exception as err:
                 logger.debug(err)
 


### PR DESCRIPTION
Add blocked accounts list on cancel instruction to prevent `BLOCKED ACCOUNTS NOT EQUAL` error.
Fix blocked accounts list acquiring in `Continue and `ExecuteTrxFromAccountDataIterative` instructions which were led to failing to find hunging transactions.
Add filling missing data to transactions added by proxy(Could be redone in proxy part after merge of #340).