### PR TITLE
#360 Process transaction too large error in iterative transactions

### DIFF
--- a/proxy/common_neon/transaction_sender.py
+++ b/proxy/common_neon/transaction_sender.py
@@ -385,6 +385,8 @@ class IterativeTransactionSender:
             return_result = self.call_continue_bucked()
         except Exception as err:
             logger.debug("call_continue_bucked_combined exception: {}".format(str(err)))
+            if str(err).startswith("transaction too large:"):
+                raise
 
         if return_result is not None:
             return return_result


### PR DESCRIPTION
Too large transaction error was not processed correctly in bucked execution.
Add passing it to the upper level for processing.