### PR TITLE
fix:  ethereum user cannot transfer eth to himself

### DIFF
--- a/proxy/common_neon/transaction_sender.py
+++ b/proxy/common_neon/transaction_sender.py
@@ -271,9 +271,10 @@ class TransactionSender:
                         code_sol = None
                         code_writable = None
 
-            elif address == sender_ether:
+            if address == sender_ether:
                 sender_sol = PublicKey(acc_desc["account"])
-            else:
+
+            if address != to_address and address != sender_ether:
                 add_keys_05.append(AccountMeta(pubkey=acc_desc["account"], is_signer=False, is_writable=True))
                 if acc_desc["new"]:
                     if code_account:


### PR DESCRIPTION
The Metamask user should be able to transfer funds to himself.
This test case caused an error.
This fix solves this problem by changing the "if-else" structure 