### PR TITLE
Introduced a metric "resp_time_ms" to understand how long the neon-proxy make a response

### DIFF
--- a/proxy/plugin/solana_rest_api.py
+++ b/proxy/plugin/solana_rest_api.py
@@ -17,6 +17,7 @@ import rlp
 import threading
 import traceback
 import unittest
+import time
 
 from ..common.utils import build_http_response
 from ..http.codes import httpStatusCodes
@@ -618,7 +619,7 @@ class SolanaProxyPlugin(HttpWebServerBasePlugin):
                     b'Access-Control-Max-Age': b'86400'
                 })))
             return
-
+        start_time = time.time()
         logger.debug('<<< %s 0x%x %s', threading.get_ident(), id(self.model), request.body.decode('utf8'))
         response = None
 
@@ -639,8 +640,10 @@ class SolanaProxyPlugin(HttpWebServerBasePlugin):
             traceback.print_exc()
             response = {'jsonrpc': '2.0', 'error': {'code': -32000, 'message': str(err)}}
 
-        logger.debug('>>> %s 0x%0x %s %s', threading.get_ident(), id(self.model), json.dumps(response),
-                     request['method'] if 'method' in request else '---')
+        resp_time_ms = (time.time() - start_time)*1000  # convert this into milliseconds
+        logger.debug('>>> %s 0x%0x %s %s resp_time_ms= %s', threading.get_ident(), id(self.model), json.dumps(response),
+                     request['method'] if 'method' in request else '---',
+                     resp_time_ms)
 
         self.client.queue(memoryview(build_http_response(
             httpStatusCodes.OK, body=json.dumps(response).encode('utf8'),

--- a/proxy/plugin/solana_rest_api.py
+++ b/proxy/plugin/solana_rest_api.py
@@ -642,7 +642,7 @@ class SolanaProxyPlugin(HttpWebServerBasePlugin):
 
         resp_time_ms = (time.time() - start_time)*1000  # convert this into milliseconds
         logger.debug('>>> %s 0x%0x %s %s resp_time_ms= %s', threading.get_ident(), id(self.model), json.dumps(response),
-                     request['method'] if 'method' in request else '---',
+                     request.get('method', '---'),
                      resp_time_ms)
 
         self.client.queue(memoryview(build_http_response(


### PR DESCRIPTION
Example from logs

`
2021-12-21 12:55:44,578 - pid:66 [D] handle_request:644 - >>> 140520376076032 0x7fcd731c4820 {"jsonrpc": "2.0", "id": 53, "result": "0x1a4113d1f89eeab26979240768d04d0757030ca398e38685a57d9104fd675f29"} eth_sendRawTransaction resp_time_ms= 469.0275192260742
`