### PR TITLE
Reduce the number of requests to solana rpc

### DIFF
--- a/proxy/common_neon/solana_interactor.py
+++ b/proxy/common_neon/solana_interactor.py
@@ -91,8 +91,19 @@ class SolanaInteractor:
         return self.client.get_balance(account, commitment=Confirmed)['result']['value']
 
 
-    def get_rent_exempt_balance_for_size(self, size):
-        return self.client.get_minimum_balance_for_rent_exemption(size, commitment=Confirmed)["result"]
+    def get_multiple_rent_exempt_balances_for_size(self, size_list: List[int]) -> List[int]:
+        request_data = []
+        for size in size_list:      
+            params = (size, {"commitment": "confirmed"})
+            request_id = next(self.client._provider._request_counter) + 1
+
+            request = {"jsonrpc": "2.0", "id": request_id, "method": "getMinimumBalanceForRentExemption", "params": params}
+            request_data.append(request)
+
+        response = requests.post(self.client._provider.endpoint_uri, headers={"Content-Type": "application/json"}, json=request_data)
+        response.raise_for_status()
+
+        return list(map(lambda r: r["result"], response.json()))
 
 
     def _getAccountData(self, account, expected_length, owner=None):

--- a/proxy/common_neon/transaction_sender.py
+++ b/proxy/common_neon/transaction_sender.py
@@ -2,6 +2,7 @@ import json
 import logging
 import math
 import os
+from typing import List
 import rlp
 import time
 
@@ -149,28 +150,24 @@ class TransactionSender:
 
 
     def create_multiple_accounts_with_seed(self, seeds, sizes):
-        accounts = []
+        accounts = list(map(lambda seed: accountWithSeed(self.sender.get_operator_key(), seed), seeds))
+        accounts_info = self.sender.get_multiple_accounts_info(accounts)
+
         trx = Transaction()
 
-        for seed, storage_size in zip(seeds, sizes):
-            account = accountWithSeed(self.sender.get_operator_key(), seed)
-            accounts.append(account)
-
-            minimum_balance = self.sender.get_rent_exempt_balance_for_size(storage_size)
-
-            account_info = self.sender.get_account_info(account)
+        for account_key, account_info, seed, storage_size in zip(accounts, accounts_info, seeds, sizes):
             if account_info is None:
+                minimum_balance = self.sender.get_rent_exempt_balance_for_size(storage_size)
                 logger.debug("Minimum balance required for account {}".format(minimum_balance))
 
-                trx.add(self.instruction.create_account_with_seed_trx(account, seed, minimum_balance, storage_size))
+                trx.add(self.instruction.create_account_with_seed_trx(account_key, seed, minimum_balance, storage_size))
             else:
-                (tag, lamports, owner) = account_info
-                if lamports < minimum_balance:
+                if account_info.lamports < minimum_balance:
                     raise Exception("insufficient balance")
-                if PublicKey(owner) != PublicKey(EVM_LOADER_ID):
+                if PublicKey(account_info.owner) != PublicKey(EVM_LOADER_ID):
                     raise Exception("wrong owner")
-                if tag not in {EMPTY_STORAGE_TAG, FINALIZED_STORAGE_TAG}:
-                                raise Exception("not empty, not finalized")
+                if account_info.tag not in {EMPTY_STORAGE_TAG, FINALIZED_STORAGE_TAG}:
+                    raise Exception("not empty, not finalized")
 
         if len(trx.instructions) > 0:
             self.sender.send_transaction(trx, eth_trx=self.eth_trx, reason='createAccountWithSeed')
@@ -342,32 +339,26 @@ class IterativeTransactionSender:
 
 
     def call_signed_iterative_combined(self):
-        self.create_accounts_for_trx()
+        if len(self.create_acc_trx.instructions) > 0:
+            create_accounts_siganture = self.sender.send_transaction_unconfirmed(self.create_acc_trx)
+            self.sender.confirm_transaction(create_accounts_siganture)
+
         self.instruction_type = self.CONTINUE_COMBINED
         return self.call_continue()
 
 
     def call_signed_with_holder_combined(self):
-        self.write_trx_to_holder_account()
-        self.create_accounts_for_trx()
+        precall_transactions = self.make_write_to_holder_account_trx()
+        if len(self.create_acc_trx.instructions) > 0:
+            precall_transactions.append(self.create_acc_trx)
+        signatures = self.sender.send_multiple_transactions_unconfirmed(precall_transactions)
+        self.sender.confirm_multiple_transactions(signatures)
+
         self.instruction_type = self.CONTINUE_HOLDER_COMB
         return self.call_continue()
 
 
-    def create_accounts_for_trx(self):
-        length = len(self.create_acc_trx.instructions)
-        if length == 0:
-            return
-        logger.debug(f"Create account for trx: {length}")
-        precall_txs = Transaction()
-        precall_txs.add(self.create_acc_trx)
-        result = self.sender.send_measured_transaction(precall_txs, self.eth_trx, 'CreateAccountsForTrx')
-        if check_for_errors(result):
-            raise Exception("Failed to create account for trx")
-        self.create_acc_trx = Transaction()
-
-
-    def write_trx_to_holder_account(self):
+    def make_write_to_holder_account_trx(self) -> List[Transaction]:
         logger.debug('write_trx_to_holder_account')
         msg = self.eth_trx.signature() + len(self.eth_trx.unsigned_msg()).to_bytes(8, byteorder="little") + self.eth_trx.unsigned_msg()
 
@@ -380,19 +371,7 @@ class IterativeTransactionSender:
             trxs.append(trx)
             offset += len(part)
 
-        while len(trxs) > 0:
-            receipts = {}
-            for trx in trxs:
-                receipts[self.sender.send_transaction_unconfirmed(trx)] = trx
-
-            logger.debug("receipts %s", receipts)
-            for rcpt, trx in receipts.items():
-                try:
-                    self.sender.collect_result(rcpt, eth_trx=self.eth_trx, reason='WriteHolder')
-                except Exception as err:
-                    logger.debug("collect_result exception: {}".format(str(err)))
-                else:
-                    trxs.remove(trx)
+        return trxs
 
 
     def call_continue(self):

--- a/proxy/common_neon/transaction_sender.py
+++ b/proxy/common_neon/transaction_sender.py
@@ -342,6 +342,7 @@ class IterativeTransactionSender:
         if len(self.create_acc_trx.instructions) > 0:
             create_accounts_siganture = self.sender.send_transaction_unconfirmed(self.create_acc_trx)
             self.sender.confirm_multiple_transactions([create_accounts_siganture])
+            self.create_acc_trx = Transaction()
 
         self.instruction_type = self.CONTINUE_COMBINED
         return self.call_continue()
@@ -353,6 +354,8 @@ class IterativeTransactionSender:
             precall_transactions.append(self.create_acc_trx)
         signatures = self.sender.send_multiple_transactions_unconfirmed(precall_transactions)
         self.sender.confirm_multiple_transactions(signatures)
+        
+        self.create_acc_trx = Transaction()
 
         self.instruction_type = self.CONTINUE_HOLDER_COMB
         return self.call_continue()

--- a/proxy/common_neon/transaction_sender.py
+++ b/proxy/common_neon/transaction_sender.py
@@ -341,7 +341,7 @@ class IterativeTransactionSender:
     def call_signed_iterative_combined(self):
         if len(self.create_acc_trx.instructions) > 0:
             create_accounts_siganture = self.sender.send_transaction_unconfirmed(self.create_acc_trx)
-            self.sender.confirm_transaction(create_accounts_siganture)
+            self.sender.confirm_multiple_transactions([create_accounts_siganture])
 
         self.instruction_type = self.CONTINUE_COMBINED
         return self.call_continue()


### PR DESCRIPTION
- Request multiple accounts at the same time
- Confirm multiple transactions at the same time
- Send multiple transactions at the same time, when writing to holder account