### PR TITLE
#365 remove prflight check

### DIFF
--- a/proxy/common_neon/costs.py
+++ b/proxy/common_neon/costs.py
@@ -1,7 +1,7 @@
 import base58
 import psycopg2
 
-from ..environment import EVM_LOADER_ID, WRITE_TRANSACTION_COST_IN_DB 
+from ..environment import EVM_LOADER_ID, WRITE_TRANSACTION_COST_IN_DB
 from ..indexer.sql_dict import POSTGRES_USER, POSTGRES_HOST, POSTGRES_DB, POSTGRES_PASSWORD
 
 class SQLCost():
@@ -50,7 +50,7 @@ def update_transaction_cost(receipt, eth_trx, extra_sol_trx=False, reason=None):
     if not WRITE_TRANSACTION_COST_IN_DB:
         return
 
-    cost = receipt['result']['meta']['preBalances'][0] - receipt['result']['meta']['postBalances'][0]
+    cost = receipt['meta']['preBalances'][0] - receipt['meta']['postBalances'][0]
     if eth_trx:
         hash = eth_trx.hash_signed().hex()
         sender = eth_trx.sender()
@@ -60,10 +60,10 @@ def update_transaction_cost(receipt, eth_trx, extra_sol_trx=False, reason=None):
         sender = None
         to_address = None
 
-    sig = receipt['result']['transaction']['signatures'][0]
+    sig = receipt['transaction']['signatures'][0]
     used_gas=None
 
-    tx_info = receipt['result']
+    tx_info = receipt
     accounts = tx_info["transaction"]["message"]["accountKeys"]
     evm_loader_instructions = []
 

--- a/proxy/common_neon/solana_interactor.py
+++ b/proxy/common_neon/solana_interactor.py
@@ -91,8 +91,19 @@ class SolanaInteractor:
         return self.client.get_balance(account, commitment=Confirmed)['result']['value']
 
 
-    def get_rent_exempt_balance_for_size(self, size):
-        return self.client.get_minimum_balance_for_rent_exemption(size, commitment=Confirmed)["result"]
+    def get_multiple_rent_exempt_balances_for_size(self, size_list: List[int]) -> List[int]:
+        request_data = []
+        for size in size_list:      
+            params = (size, {"commitment": "confirmed"})
+            request_id = next(self.client._provider._request_counter) + 1
+
+            request = {"jsonrpc": "2.0", "id": request_id, "method": "getMinimumBalanceForRentExemption", "params": params}
+            request_data.append(request)
+
+        response = requests.post(self.client._provider.endpoint_uri, headers={"Content-Type": "application/json"}, json=request_data)
+        response.raise_for_status()
+
+        return list(map(lambda r: r["result"], response.json()))
 
 
     def _getAccountData(self, account, expected_length, owner=None):

--- a/proxy/common_neon/solana_interactor.py
+++ b/proxy/common_neon/solana_interactor.py
@@ -197,7 +197,7 @@ class SolanaInteractor:
     def confirm_multiple_transactions(self, signatures: List[Union[str, bytes]]):
         """Confirm a transaction."""
         # TODO should be set as predefined constant
-        TIMEOUT = 5  # 30 seconds  pylint: disable=invalid-name
+        TIMEOUT = 10  # 30 seconds  pylint: disable=invalid-name
         elapsed_time = 0
         while elapsed_time < TIMEOUT:
             response = self.client.get_signature_statuses(signatures)

--- a/proxy/common_neon/solana_interactor.py
+++ b/proxy/common_neon/solana_interactor.py
@@ -174,7 +174,6 @@ class SolanaInteractor:
         response = self._send_rpc_batch_request("sendTransaction", request)
         return list(map(lambda r: r["result"], response))
 
-
     def send_measured_transaction(self, trx, eth_trx, reason):
         if LOG_SENDING_SOLANA_TRANSACTION:
             logger.debug("send_measured_transaction for reason %s: %s ", reason, trx.__dict__)

--- a/proxy/common_neon/solana_interactor.py
+++ b/proxy/common_neon/solana_interactor.py
@@ -257,3 +257,41 @@ def check_if_continue_returned(result):
                         return tx_info['transaction']['signatures'][0]
 
     return None
+
+
+def get_logs_from_reciept(receipt):
+    log_from_reciept = get_from_dict(receipt, 'result', 'meta', 'logMessages')
+    if log_from_reciept is not None:
+        return log_from_reciept
+
+    log_from_reciept_result = get_from_dict(receipt, 'meta', 'logMessages')
+    if log_from_reciept_result is not None:
+        return log_from_reciept_result
+
+    log_from_reciept_result_meta = get_from_dict(receipt, 'logMessages')
+    if log_from_reciept_result_meta is not None:
+        return log_from_reciept_result_meta
+
+    log_from_send_trx_error = get_from_dict(receipt, 'data', 'logs')
+    if log_from_send_trx_error is not None:
+        return log_from_send_trx_error
+
+    log_from_prepared_receipt = get_from_dict(receipt, 'logs')
+    if log_from_prepared_receipt is not None:
+        return log_from_prepared_receipt
+
+    return None
+
+
+def check_if_accounts_blocked(receipt):
+    logs = get_logs_from_reciept(receipt)
+    if logs is None:
+        logger.error("Can't get logs")
+        logger.info("Failed result: %s"%json.dumps(receipt, indent=3))
+
+    ro_blocked = "trying to execute transaction on ro locked account"
+    rw_blocked = "trying to execute transaction on rw locked account"
+    for log in logs:
+        if log.find(ro_blocked) >= 0 or log.find(rw_blocked) >= 0:
+            return True
+    return False

--- a/proxy/common_neon/transaction_sender.py
+++ b/proxy/common_neon/transaction_sender.py
@@ -2,6 +2,7 @@ import json
 import logging
 import math
 import os
+from typing import List
 import rlp
 import time
 
@@ -149,28 +150,24 @@ class TransactionSender:
 
 
     def create_multiple_accounts_with_seed(self, seeds, sizes):
-        accounts = []
+        accounts = list(map(lambda seed: accountWithSeed(self.sender.get_operator_key(), seed), seeds))
+        accounts_info = self.sender.get_multiple_accounts_info(accounts)
+
         trx = Transaction()
 
-        for seed, storage_size in zip(seeds, sizes):
-            account = accountWithSeed(self.sender.get_operator_key(), seed)
-            accounts.append(account)
-
-            minimum_balance = self.sender.get_rent_exempt_balance_for_size(storage_size)
-
-            account_info = self.sender.get_account_info(account)
+        for account_key, account_info, seed, storage_size in zip(accounts, accounts_info, seeds, sizes):
             if account_info is None:
+                minimum_balance = self.sender.get_rent_exempt_balance_for_size(storage_size)
                 logger.debug("Minimum balance required for account {}".format(minimum_balance))
 
-                trx.add(self.instruction.create_account_with_seed_trx(account, seed, minimum_balance, storage_size))
+                trx.add(self.instruction.create_account_with_seed_trx(account_key, seed, minimum_balance, storage_size))
             else:
-                (tag, lamports, owner) = account_info
-                if lamports < minimum_balance:
+                if account_info.lamports < minimum_balance:
                     raise Exception("insufficient balance")
-                if PublicKey(owner) != PublicKey(EVM_LOADER_ID):
+                if PublicKey(account_info.owner) != PublicKey(EVM_LOADER_ID):
                     raise Exception("wrong owner")
-                if tag not in {EMPTY_STORAGE_TAG, FINALIZED_STORAGE_TAG}:
-                                raise Exception("not empty, not finalized")
+                if account_info.tag not in {EMPTY_STORAGE_TAG, FINALIZED_STORAGE_TAG}:
+                    raise Exception("not empty, not finalized")
 
         if len(trx.instructions) > 0:
             self.sender.send_transaction(trx, eth_trx=self.eth_trx, reason='createAccountWithSeed')
@@ -342,32 +339,26 @@ class IterativeTransactionSender:
 
 
     def call_signed_iterative_combined(self):
-        self.create_accounts_for_trx()
+        if len(self.create_acc_trx.instructions) > 0:
+            create_accounts_siganture = self.sender.send_transaction_unconfirmed(self.create_acc_trx)
+            self.sender.confirm_transaction(create_accounts_siganture)
+
         self.instruction_type = self.CONTINUE_COMBINED
         return self.call_continue()
 
 
     def call_signed_with_holder_combined(self):
-        self.write_trx_to_holder_account()
-        self.create_accounts_for_trx()
+        precall_transactions = self.make_write_to_holder_account_trx()
+        if len(self.create_acc_trx.instructions) > 0:
+            precall_transactions.append(self.create_acc_trx)
+        signatures = self.sender.send_multiple_transactions_unconfirmed(precall_transactions)
+        self.sender.confirm_multiple_transactions(signatures)
+
         self.instruction_type = self.CONTINUE_HOLDER_COMB
         return self.call_continue()
 
 
-    def create_accounts_for_trx(self):
-        length = len(self.create_acc_trx.instructions)
-        if length == 0:
-            return
-        logger.debug(f"Create account for trx: {length}")
-        precall_txs = Transaction()
-        precall_txs.add(self.create_acc_trx)
-        result = self.sender.send_measured_transaction(precall_txs, self.eth_trx, 'CreateAccountsForTrx')
-        if check_for_errors(result):
-            raise Exception("Failed to create account for trx")
-        self.create_acc_trx = Transaction()
-
-
-    def write_trx_to_holder_account(self):
+    def make_write_to_holder_account_trx(self) -> List[Transaction]:
         logger.debug('write_trx_to_holder_account')
         msg = self.eth_trx.signature() + len(self.eth_trx.unsigned_msg()).to_bytes(8, byteorder="little") + self.eth_trx.unsigned_msg()
 
@@ -380,19 +371,7 @@ class IterativeTransactionSender:
             trxs.append(trx)
             offset += len(part)
 
-        while len(trxs) > 0:
-            receipts = {}
-            for trx in trxs:
-                receipts[self.sender.send_transaction_unconfirmed(trx)] = trx
-
-            logger.debug("receipts %s", receipts)
-            for rcpt, trx in receipts.items():
-                try:
-                    self.sender.collect_result(rcpt, eth_trx=self.eth_trx, reason='WriteHolder')
-                except Exception as err:
-                    logger.debug("collect_result exception: {}".format(str(err)))
-                else:
-                    trxs.remove(trx)
+        return trxs
 
 
     def call_continue(self):

--- a/proxy/common_neon/transaction_sender.py
+++ b/proxy/common_neon/transaction_sender.py
@@ -342,6 +342,7 @@ class IterativeTransactionSender:
         if len(self.create_acc_trx.instructions) > 0:
             create_accounts_siganture = self.sender.send_transaction_unconfirmed(self.create_acc_trx)
             self.sender.confirm_multiple_transactions([create_accounts_siganture])
+            self.create_acc_trx = Transaction()
 
         self.instruction_type = self.CONTINUE_COMBINED
         return self.call_continue()
@@ -353,6 +354,8 @@ class IterativeTransactionSender:
             precall_transactions.append(self.create_acc_trx)
         signatures = self.sender.send_multiple_transactions_unconfirmed(precall_transactions)
         self.sender.confirm_multiple_transactions(signatures)
+        
+        self.create_acc_trx = Transaction()
 
         self.instruction_type = self.CONTINUE_HOLDER_COMB
         return self.call_continue()

--- a/proxy/common_neon/transaction_sender.py
+++ b/proxy/common_neon/transaction_sender.py
@@ -341,7 +341,7 @@ class IterativeTransactionSender:
     def call_signed_iterative_combined(self):
         if len(self.create_acc_trx.instructions) > 0:
             create_accounts_siganture = self.sender.send_transaction_unconfirmed(self.create_acc_trx)
-            self.sender.confirm_transaction(create_accounts_siganture)
+            self.sender.confirm_multiple_transactions([create_accounts_siganture])
 
         self.instruction_type = self.CONTINUE_COMBINED
         return self.call_continue()

--- a/proxy/common_neon/transaction_sender.py
+++ b/proxy/common_neon/transaction_sender.py
@@ -424,7 +424,7 @@ class IterativeTransactionSender:
             try_one_step = False
             found_errors = False
 
-            logger.debug(f"Send bucked combined: {self.instruction_type}")
+            logger.debug(f"Send pack of combined: {self.instruction_type}")
             trxs = []
             for index in range(self.steps_count()):
                 trxs.append(self.make_combined_trx(self.steps, index))

--- a/proxy/common_neon/transaction_sender.py
+++ b/proxy/common_neon/transaction_sender.py
@@ -497,7 +497,9 @@ class IterativeTransactionSender:
                 if not check_error(result):
                     self.success_steps += 1
                     self.sender.get_measurements(result)
-                    success_signature = check_if_continue_returned(result)
+                    signature = check_if_continue_returned(result)
+                    if success_signature is not None:
+                        success_signature = signature
                 elif check_if_accounts_blocked(result):
                     logger.debug("Blocked account")
                     retry_on_blocked -= 1

--- a/proxy/common_neon/transaction_sender.py
+++ b/proxy/common_neon/transaction_sender.py
@@ -95,10 +95,6 @@ class TransactionSender:
             self.free_perm_accs()
 
 
-    def create_instruction_constructor(self):
-        return NeonInstruction(self.sender.get_operator_key(), self.eth_trx, self.eth_accounts, self.caller_token)
-
-
     def create_noniterative_executor(self):
         self.instruction.init_eth_trx(self.eth_trx, self.eth_accounts, self.caller_token)
         return NoniterativeTransactionSender(self.sender, self.instruction, self.create_acc_trx, self.eth_trx)

--- a/proxy/common_neon/transaction_sender.py
+++ b/proxy/common_neon/transaction_sender.py
@@ -415,7 +415,7 @@ class IterativeTransactionSender:
             found_errors = False
             logger.debug("Send bucked combined: %s", self.instruction_type)
             receipts = []
-            for index in range(math.ceil(self.steps_emulated/self.steps) + self.addition_count() - self.success_steps):
+            for index in range(self.steps_count()):
                 trx = self.make_combined_trx(self.steps, index)
                 receipts.append(self.sender.send_transaction_unconfirmed(trx))
 
@@ -477,6 +477,14 @@ class IterativeTransactionSender:
         logger.debug("Cancel")
         result = self.sender.send_measured_transaction(trx, self.eth_trx, 'CancelWithNonce')
         return result['transaction']['signatures'][0]
+
+
+    def steps_count(self):
+        counted_steps = math.ceil(self.steps_emulated/self.steps) + self.addition_count()
+        if self.success_steps >= counted_steps:
+            return counted_steps
+        else:
+            counted_steps - self.success_steps
 
 
     def addition_count(self):

--- a/proxy/common_neon/transaction_sender.py
+++ b/proxy/common_neon/transaction_sender.py
@@ -58,6 +58,14 @@ class TransactionSender:
                 if "Program failed to complete" in errStr or "Computational budget exceeded" in errStr:
                     logger.debug("Program exceeded instructions")
                     if self.steps_emulated / self.steps > self.steps / 2:
+                        """
+                            An iterative call from instruction data can be performed in batches only
+                            with a change in the number of steps in the iteration.
+                            Each next iteration the number of steps decreases.
+                            Thus, starting from a certain number of steps,
+                            it is appropriate to use a call from the account data,
+                            since there the number of steps is unchanged.
+                        """
                         call_from_holder = True
                     else:
                         call_iterative = True

--- a/proxy/common_neon/transaction_sender.py
+++ b/proxy/common_neon/transaction_sender.py
@@ -498,7 +498,7 @@ class IterativeTransactionSender:
                     self.success_steps += 1
                     self.sender.get_measurements(result)
                     signature = check_if_continue_returned(result)
-                    if success_signature is not None:
+                    if signature is not None:
                         success_signature = signature
                 elif check_if_accounts_blocked(result):
                     logger.debug("Blocked account")

--- a/proxy/common_neon/transaction_sender.py
+++ b/proxy/common_neon/transaction_sender.py
@@ -398,12 +398,12 @@ class IterativeTransactionSender:
                 logger.debug(f'write {len(trxs)} trxs')
                 receipts = self.sender.send_multiple_transactions_unconfirmed(trxs)
                 results = self.sender.collect_results(receipts, eth_trx=self.eth_trx, reason='WriteHolder')
-                logger.debug(f'trxs {len(trxs)} receipts {len(receipts)} write {len(results)} ')
 
+                success_trxs = []
                 for result, trx in zip(results, trxs):
-                    logger.debug(f'result {result}')
                     if result is not None:
-                        trxs.remove(trx)
+                        success_trxs.append(trx)
+                trxs = [trx for trx in trxs if trx not in success_trxs]
 
 
     def call_continue(self):

--- a/proxy/common_neon/transaction_sender.py
+++ b/proxy/common_neon/transaction_sender.py
@@ -484,7 +484,7 @@ class IterativeTransactionSender:
         if self.success_steps >= counted_steps:
             return counted_steps
         else:
-            counted_steps - self.success_steps
+            return counted_steps - self.success_steps
 
 
     def addition_count(self):

--- a/proxy/common_neon/transaction_sender.py
+++ b/proxy/common_neon/transaction_sender.py
@@ -430,8 +430,10 @@ class IterativeTransactionSender:
                         if signature:
                             return signature
                     elif check_if_accounts_blocked(result):
+                        logger.debug("Blocked account")
                         try_one_step = True
                     elif check_if_program_exceeded_instructions(result):
+                        logger.debug("Compute Limit")
                         try_one_step = True
                     else:
                         logs += get_logs_from_reciept(result)
@@ -451,8 +453,10 @@ class IterativeTransactionSender:
                         if signature:
                             return signature
                     elif check_if_accounts_blocked(result):
+                        logger.debug("Blocked account")
                         time.sleep(0.5)
                     elif check_if_program_exceeded_instructions(result):
+                        logger.debug("Compute Limit")
                         step_count = int(step_count * 90 / 100)
                     else:
                         logs = get_logs_from_reciept(result)

--- a/proxy/environment.py
+++ b/proxy/environment.py
@@ -19,6 +19,7 @@ EXTRA_GAS = int(os.environ.get("EXTRA_GAS", "0"))
 LOG_SENDING_SOLANA_TRANSACTION = os.environ.get("LOG_SENDING_SOLANA_TRANSACTION", "NO") == "YES"
 LOG_NEON_CLI_DEBUG = os.environ.get("LOG_NEON_CLI_DEBUG", "NO") == "YES"
 WRITE_TRANSACTION_COST_IN_DB = os.environ.get("WRITE_TRANSACTION_COST_IN_DB", "NO") == "YES"
+RETRY_ON_BLOCKED = int(os.environ.get("RETRY_ON_BLOCKED", "32"))
 
 class solana_cli:
     def call(self, *args):

--- a/proxy/environment.py
+++ b/proxy/environment.py
@@ -19,7 +19,7 @@ EXTRA_GAS = int(os.environ.get("EXTRA_GAS", "0"))
 LOG_SENDING_SOLANA_TRANSACTION = os.environ.get("LOG_SENDING_SOLANA_TRANSACTION", "NO") == "YES"
 LOG_NEON_CLI_DEBUG = os.environ.get("LOG_NEON_CLI_DEBUG", "NO") == "YES"
 WRITE_TRANSACTION_COST_IN_DB = os.environ.get("WRITE_TRANSACTION_COST_IN_DB", "NO") == "YES"
-RETRY_ON_BLOCKED = int(os.environ.get("RETRY_ON_BLOCKED", "32"))
+RETRY_ON_BLOCKED = max(int(os.environ.get("RETRY_ON_BLOCKED", "32")), 1)
 RETRY_ON_FAIL = int(os.environ.get("RETRY_ON_FAIL", "2"))
 
 class solana_cli:

--- a/proxy/run-proxy.sh
+++ b/proxy/run-proxy.sh
@@ -12,6 +12,7 @@ if [ "$CONFIG" == "ci" ]; then
   [[ -z "$MINIMAL_GAS_PRICE"            ]] && export MINIMAL_GAS_PRICE=0
   [[ -z "$POSTGRES_HOST"                ]] && export POSTGRES_HOST="postgres"
   [[ -z "$CANCEL_TIMEOUT"               ]] && export CANCEL_TIMEOUT=10
+  [[ -z "$RETRY_ON_BLOCKED"             ]] && export RETRY_ON_BLOCKED=32
 elif [ "$CONFIG" == "local" ]; then
   [[ -z "$SOLANA_URL"                   ]] && export SOLANA_URL="http://localhost:8899"
   [[ -z "$EXTRA_GAS"                    ]] && export EXTRA_GAS=0
@@ -19,6 +20,7 @@ elif [ "$CONFIG" == "local" ]; then
   [[ -z "$MINIMAL_GAS_PRICE"            ]] && export MINIMAL_GAS_PRICE=0
   [[ -z "$POSTGRES_HOST"                ]] && export POSTGRES_HOST="localhost"
   [[ -z "$CANCEL_TIMEOUT"               ]] && export CANCEL_TIMEOUT=10
+  [[ -z "$RETRY_ON_BLOCKED"             ]] && export RETRY_ON_BLOCKED=32
 elif [ "$CONFIG" == "devnet" ]; then
   [[ -z "$SOLANA_URL"                   ]] && export SOLANA_URL="https://api.devnet.solana.com"
   [[ -z "$EVM_LOADER"                   ]] && export EVM_LOADER=eeLSJgWzzxrqKv1UxtRVVH8FX3qCQWUs9QuAjJpETGU
@@ -27,6 +29,7 @@ elif [ "$CONFIG" == "devnet" ]; then
   [[ -z "$MINIMAL_GAS_PRICE"            ]] && export MINIMAL_GAS_PRICE=1
   [[ -z "$POSTGRES_HOST"                ]] && export POSTGRES_HOST="localhost"
   [[ -z "$CANCEL_TIMEOUT"               ]] && export CANCEL_TIMEOUT=60
+  [[ -z "$RETRY_ON_BLOCKED"             ]] && export RETRY_ON_BLOCKED=32
 elif [ "$CONFIG" == "testnet" ]; then
   [[ -z "$SOLANA_URL"                   ]] && export SOLANA_URL="https://api.testnet.solana.com"
   [[ -z "$EVM_LOADER"                   ]] && export EVM_LOADER=eeLSJgWzzxrqKv1UxtRVVH8FX3qCQWUs9QuAjJpETGU
@@ -35,6 +38,7 @@ elif [ "$CONFIG" == "testnet" ]; then
   [[ -z "$MINIMAL_GAS_PRICE"            ]] && export MINIMAL_GAS_PRICE="1"
   [[ -z "$POSTGRES_HOST"                ]] && export POSTGRES_HOST="localhost"
   [[ -z "$CANCEL_TIMEOUT"               ]] && export CANCEL_TIMEOUT=60
+  [[ -z "$RETRY_ON_BLOCKED"             ]] && export RETRY_ON_BLOCKED=32
 elif [ "$CONFIG" != "custom" ]; then
   exit 1
 fi

--- a/proxy/testing/test_retry_on_blocked_accounts.py
+++ b/proxy/testing/test_retry_on_blocked_accounts.py
@@ -56,7 +56,7 @@ contract BlockForAWhile {
 '''
 
 
-def send_in_parallel(acc_seed, contractAddress, abi, loop, return_dict):
+def send_routine(acc_seed, contractAddress, abi, loop, return_dict):
     print("Send parallel transaction from {}".format(acc_seed))
     print(datetime.datetime.now().time())
     storage_contract = proxy.eth.contract(
@@ -248,7 +248,7 @@ class BlockedTest(unittest.TestCase):
         caller_seed = "long"
         manager = multiprocessing.Manager()
         return_dict = manager.dict()
-        p2 = multiprocessing.Process(target=send_in_parallel, args=(caller_seed, self.contractAddress, self.abi, 1000, return_dict))
+        p2 = multiprocessing.Process(target=send_routine, args=(caller_seed, self.contractAddress, self.abi, 1000, return_dict))
         p2.start()
         while True:
             try:
@@ -265,7 +265,7 @@ class BlockedTest(unittest.TestCase):
         caller_seed = "short"
         manager = multiprocessing.Manager()
         return_dict = manager.dict()
-        p2 = multiprocessing.Process(target=send_in_parallel, args=(caller_seed, self.contractAddress, self.abi, 10, return_dict))
+        p2 = multiprocessing.Process(target=send_routine, args=(caller_seed, self.contractAddress, self.abi, 10, return_dict))
         p2.start()
         while True:
             try:

--- a/proxy/testing/test_retry_on_blocked_accounts.py
+++ b/proxy/testing/test_retry_on_blocked_accounts.py
@@ -47,7 +47,7 @@ pragma solidity >=0.5.12;
 contract BlockForAWhile {
     uint32 counter = 0;
 
-    function add_some(uint32 some, uint32 loop) public {
+    function add_some(uint32 some, uint32 loop, string memory _padding) public {
         for(uint32 i = 0; i < loop; i++){
             counter += some + i;
         }
@@ -56,7 +56,7 @@ contract BlockForAWhile {
 '''
 
 
-def send_routine(acc_seed, contractAddress, abi, loop, return_dict):
+def send_routine(acc_seed, contractAddress, abi, loop, return_dict, padding_string):
     print("Send parallel transaction from {}".format(acc_seed))
     print(datetime.datetime.now().time())
     storage_contract = proxy.eth.contract(
@@ -65,7 +65,7 @@ def send_routine(acc_seed, contractAddress, abi, loop, return_dict):
         )
     new_eth_account = proxy.eth.account.create(acc_seed)
     right_nonce = proxy.eth.get_transaction_count(new_eth_account.address)
-    trx_store = storage_contract.functions.add_some(2, loop).buildTransaction(
+    trx_store = storage_contract.functions.add_some(2, loop, padding_string).buildTransaction(
         {
             "chainId": proxy.eth.chain_id,
             "gas": 987654321,
@@ -157,7 +157,7 @@ class BlockedTest(unittest.TestCase):
     def create_blocked_transaction(self):
         print("\ncreate_blocked_transaction")
         right_nonce = proxy.eth.get_transaction_count(proxy.eth.default_account)
-        trx_store = self.storage_contract.functions.add_some(1, 30).buildTransaction({'nonce': right_nonce, 'gasPrice': MINIMAL_GAS_PRICE})
+        trx_store = self.storage_contract.functions.add_some(1, 30, "").buildTransaction({'nonce': right_nonce, 'gasPrice': MINIMAL_GAS_PRICE})
         trx_store_signed = proxy.eth.account.sign_transaction(trx_store, eth_account.key)
 
         (from_addr, sign, msg) = make_instruction_data_from_tx(trx_store_signed.rawTransaction.hex())
@@ -255,7 +255,19 @@ class BlockedTest(unittest.TestCase):
         caller_seed = "long"
         manager = multiprocessing.Manager()
         return_dict = manager.dict()
-        p2 = multiprocessing.Process(target=send_routine, args=(caller_seed, self.contractAddress, self.abi, 1000, return_dict))
+        p2 = multiprocessing.Process(target=send_routine, args=(caller_seed, self.contractAddress, self.abi, 1000, return_dict,
+        """
+        1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
+        1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
+        1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
+        1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
+        1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
+        1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
+        1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
+        1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
+        1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
+        1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
+        """))
         p2.start()
         self.finish_blocker_transaction()
         p2.join()
@@ -268,7 +280,7 @@ class BlockedTest(unittest.TestCase):
         caller_seed = "short"
         manager = multiprocessing.Manager()
         return_dict = manager.dict()
-        p2 = multiprocessing.Process(target=send_routine, args=(caller_seed, self.contractAddress, self.abi, 10, return_dict))
+        p2 = multiprocessing.Process(target=send_routine, args=(caller_seed, self.contractAddress, self.abi, 10, return_dict, ""))
         p2.start()
         self.finish_blocker_transaction()
         p2.join()

--- a/proxy/testing/test_retry_on_blocked_accounts.py
+++ b/proxy/testing/test_retry_on_blocked_accounts.py
@@ -255,7 +255,7 @@ class BlockedTest(unittest.TestCase):
         caller_seed = "long"
         manager = multiprocessing.Manager()
         return_dict = manager.dict()
-        p2 = multiprocessing.Process(target=send_routine, args=(caller_seed, self.contractAddress, self.abi, 1000, return_dict,
+        p2 = multiprocessing.Process(target=send_routine, args=(caller_seed, self.contractAddress, self.abi, 50, return_dict,
         """
         1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
         1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890

--- a/proxy/testing/test_retry_on_blocked_accounts.py
+++ b/proxy/testing/test_retry_on_blocked_accounts.py
@@ -1,0 +1,282 @@
+import os
+
+from proxy.common_neon.constants import SYSVAR_INSTRUCTION_PUBKEY
+from proxy.environment import ETH_TOKEN_MINT_ID, MINIMAL_GAS_PRICE
+
+os.environ['SOLANA_URL'] = "http://solana:8899"
+os.environ['EVM_LOADER'] = "53DfF883gyixYNXnM7s5xhdeyV8mVk9T4i2hGV9vG9io"
+os.environ['ETH_TOKEN_MINT'] = "HPsV9Deocecw3GeZv1FkAPNCBRfuVyfw9MMwjwRe1xaU"
+os.environ['COLLATERAL_POOL_BASE'] = "4sW3SZDJB7qXUyCYKA7pFL8eCTfm3REr8oSiKkww7MaT"
+
+import base64
+import datetime
+import multiprocessing
+import unittest
+import rlp
+from eth_tx_utils import make_instruction_data_from_tx, make_keccak_instruction_data
+from eth_utils import big_endian_to_int
+from ethereum.transactions import Transaction as EthTrx
+from ethereum.utils import sha3
+from solana.publickey import PublicKey
+from solana.rpc.commitment import Confirmed
+from solana.system_program import SYS_PROGRAM_ID
+from solana.transaction import AccountMeta, Transaction, TransactionInstruction
+from solana_utils import *
+from solcx import install_solc
+from spl.token.constants import TOKEN_PROGRAM_ID
+from spl.token.instructions import get_associated_token_address
+from web3 import Web3
+from web3.auto.gethdev import w3
+
+install_solc(version='0.7.0')
+from solcx import compile_source
+
+SEED = 'https://github.com/neonlabsorg/proxy-model.py/issues/365'
+proxy_url = os.environ.get('PROXY_URL', 'http://localhost:9090/solana')
+proxy = Web3(Web3.HTTPProvider(proxy_url))
+eth_account = proxy.eth.account.create(SEED)
+proxy.eth.default_account = eth_account.address
+
+ACCOUNT_SEED_VERSION=b'\1'
+
+
+TEST_RETRY_BLOCKED_365 = '''
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.5.12;
+
+contract BlockForAWhile {
+    uint32 counter = 0;
+
+    function add_some(uint32 some, uint32 loop) public {
+        for(uint32 i = 0; i < loop; i++){
+            counter += some + i;
+        }
+    }
+}
+'''
+
+
+def send_in_parallel(acc_seed, contractAddress, abi, loop, return_dict):
+    print("Send parallel transaction from {}".format(acc_seed))
+    print(datetime.datetime.now().time())
+    storage_contract = proxy.eth.contract(
+            address=contractAddress,
+            abi=abi
+        )
+    new_eth_account = proxy.eth.account.create(acc_seed)
+    right_nonce = proxy.eth.get_transaction_count(new_eth_account.address)
+    trx_store = storage_contract.functions.add_some(2, loop).buildTransaction(
+        {
+            "chainId": proxy.eth.chain_id,
+            "gas": 987654321,
+            "gasPrice": 0,
+            "nonce": right_nonce,
+        }
+    )
+    trx_store_signed = proxy.eth.account.sign_transaction(trx_store, new_eth_account.key)
+    trx_store_hash = proxy.eth.send_raw_transaction(trx_store_signed.rawTransaction)
+    trx_store_receipt = proxy.eth.wait_for_transaction_receipt(trx_store_hash)
+    return_dict[acc_seed] = trx_store_receipt
+
+
+class BlockedTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        print("\ntest_retry_on_blocked_accounts.py setUpClass")
+
+        cls.token = SplToken(solana_url)
+        wallet = WalletAccount(wallet_path())
+        cls.loader = EvmLoader(wallet, EVM_LOADER)
+        cls.acc = wallet.get_acc()
+
+        cls.deploy_contract(cls)
+
+        print(cls.storage_contract.address)
+
+        cls.reId_eth = cls.storage_contract.address.lower()
+        print ('contract_eth', cls.reId_eth)
+        (cls.reId, cls.reId_token, cls.re_code) = cls.get_accounts(cls, cls.reId_eth)
+        print ('contract', cls.reId)
+        print ('contract_code', cls.re_code)
+
+        proxy.eth.default_account
+        # Create ethereum account for user account
+        cls.caller_ether = proxy.eth.default_account.lower()
+        (cls.caller, cls.caller_token, _) = cls.get_accounts(cls, cls.caller_ether)
+        print ('caller_ether', cls.caller_ether)
+        print ('caller', cls.caller)
+
+        if getBalance(cls.caller) == 0:
+            print("Create caller account...")
+            _ = cls.loader.createEtherAccount(cls.caller_ether)
+            print("Done\n")
+        # cls.token.transfer(ETH_TOKEN_MINT_ID, 2000, cls.caller_token)
+
+        collateral_pool_index = 2
+        cls.collateral_pool_address = create_collateral_pool_address(collateral_pool_index)
+        cls.collateral_pool_index_buf = collateral_pool_index.to_bytes(4, 'little')
+
+    def get_accounts(self, ether):
+        (sol_address, _) = self.loader.ether2program(ether)
+        info = client.get_account_info(sol_address, commitment=Confirmed)['result']['value']
+        data = base64.b64decode(info['data'][0])
+        acc_info = ACCOUNT_INFO_LAYOUT.parse(data)
+
+        code_address = PublicKey(acc_info.code_account)
+        alternate_token = get_associated_token_address(PublicKey(sol_address), ETH_TOKEN_MINT_ID)
+
+        return (sol_address, alternate_token, code_address)
+
+    def deploy_contract(self):
+        compiled_sol = compile_source(TEST_RETRY_BLOCKED_365)
+        contract_id, contract_interface = compiled_sol.popitem()
+        storage = proxy.eth.contract(abi=contract_interface['abi'], bytecode=contract_interface['bin'])
+        trx_deploy = proxy.eth.account.sign_transaction(dict(
+            nonce=proxy.eth.get_transaction_count(proxy.eth.default_account),
+            chainId=proxy.eth.chain_id,
+            gas=987654321,
+            gasPrice=0,
+            to='',
+            value=0,
+            data=storage.bytecode),
+            eth_account.key
+        )
+        trx_deploy_hash = proxy.eth.send_raw_transaction(trx_deploy.rawTransaction)
+        print('trx_deploy_hash:', trx_deploy_hash.hex())
+        trx_deploy_receipt = proxy.eth.wait_for_transaction_receipt(trx_deploy_hash)
+        print('trx_deploy_receipt:', trx_deploy_receipt)
+
+        self.contractAddress = trx_deploy_receipt.contractAddress
+        self.abi = storage.abi
+
+        self.storage_contract = proxy.eth.contract(
+            address=trx_deploy_receipt.contractAddress,
+            abi=storage.abi
+        )
+
+    def create_blocked_transaction(self):
+        print("\ncreate_blocked_transaction")
+        right_nonce = proxy.eth.get_transaction_count(proxy.eth.default_account)
+        trx_store = self.storage_contract.functions.add_some(1, 30).buildTransaction({'nonce': right_nonce, 'gasPrice': MINIMAL_GAS_PRICE})
+        trx_store_signed = proxy.eth.account.sign_transaction(trx_store, eth_account.key)
+
+        (from_addr, sign, msg) = make_instruction_data_from_tx(trx_store_signed.rawTransaction.hex())
+        instruction = from_addr + sign + msg
+
+        (_trx_raw, self.tx_hash, from_address) = self.get_trx_receipts(msg, sign)
+        print(self.tx_hash)
+        print(from_address)
+
+        self.storage = self.create_storage_account(sign[:8].hex())
+        print("storage", self.storage)
+        self.combined_trx = self.make_combined_transaction(self.storage, 500, msg, instruction)
+        return send_transaction(client, self.combined_trx, self.acc)
+
+    def get_trx_receipts(self, unsigned_msg, signature):
+        trx = rlp.decode(unsigned_msg, EthTrx)
+
+        v = int(signature[64]) + 35 + 2 * trx[6]
+        r = big_endian_to_int(signature[0:32])
+        s = big_endian_to_int(signature[32:64])
+
+        trx_raw = rlp.encode(EthTrx(trx[0], trx[1], trx[2], trx[3], trx[4], trx[5], v, r, s), EthTrx)
+        eth_signature = '0x' + sha3(trx_raw).hex()
+        from_address = w3.eth.account.recover_transaction(trx_raw).lower()
+
+        return (trx_raw.hex(), eth_signature, from_address)
+
+
+    def sol_instr_partial_call_or_continue(self, storage_account, step_count, evm_instruction):
+        return TransactionInstruction(
+            program_id=self.loader.loader_id,
+            data=bytearray.fromhex("0D") + self.collateral_pool_index_buf + step_count.to_bytes(8, byteorder='little') + evm_instruction,
+            keys=[
+                AccountMeta(pubkey=storage_account, is_signer=False, is_writable=True),
+
+                # System instructions account:
+                AccountMeta(pubkey=PublicKey(SYSVAR_INSTRUCTION_PUBKEY), is_signer=False, is_writable=False),
+                # Operator address:
+                AccountMeta(pubkey=self.acc.public_key(), is_signer=True, is_writable=True),
+                # Collateral pool address:
+                AccountMeta(pubkey=self.collateral_pool_address, is_signer=False, is_writable=True),
+                # Operator's NEON token account:
+                AccountMeta(pubkey=get_associated_token_address(self.acc.public_key(), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+                # User's NEON token account:
+                AccountMeta(pubkey=self.caller_token, is_signer=False, is_writable=True),
+                # System program account:
+                AccountMeta(pubkey=PublicKey(SYS_PROGRAM_ID), is_signer=False, is_writable=False),
+
+                AccountMeta(pubkey=self.reId, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=self.re_code, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=self.caller, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=self.caller_token, is_signer=False, is_writable=True),
+
+                AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
+                AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
+                AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
+            ])
+
+
+    def sol_instr_keccak(self, keccak_instruction):
+        return TransactionInstruction(program_id=keccakprog, data=keccak_instruction, keys=[
+                AccountMeta(pubkey=PublicKey(keccakprog), is_signer=False, is_writable=False), ])
+
+
+    def make_combined_transaction(self, storage, steps, msg, instruction):
+        print("make_combined_transaction")
+        trx = Transaction()
+        trx.add(self.sol_instr_keccak(make_keccak_instruction_data(1, len(msg), 13)))
+        trx.add(self.sol_instr_partial_call_or_continue(storage, steps, instruction))
+        print(trx.__dict__)
+        return trx
+
+
+    def create_storage_account(self, seed):
+        storage = PublicKey(sha256(bytes(self.acc.public_key()) + bytes(seed, 'utf8') + bytes(PublicKey(EVM_LOADER))).digest())
+        print("Storage", storage)
+
+        if getBalance(storage) == 0:
+            trx = Transaction()
+            trx.add(createAccountWithSeed(self.acc.public_key(), self.acc.public_key(), seed, 10**9, 128*1024, PublicKey(EVM_LOADER)))
+            send_transaction(client, trx, self.acc)
+
+        return storage
+
+    def test_blocked_iterative(self):
+        print("\ntest_blocked_iterative")
+        self.create_blocked_transaction()
+        caller_seed = "long"
+        manager = multiprocessing.Manager()
+        return_dict = manager.dict()
+        p2 = multiprocessing.Process(target=send_in_parallel, args=(caller_seed, self.contractAddress, self.abi, 1000, return_dict))
+        p2.start()
+        while True:
+            try:
+                send_transaction(client, self.combined_trx, self.acc)
+            except:
+                break
+        p2.join()
+        print('return_dict:', return_dict)
+        self.assertEqual(return_dict[caller_seed]['status'], 1)
+
+    def test_blocked_single(self):
+        print("\ntest_blocked_single")
+        self.create_blocked_transaction()
+        caller_seed = "short"
+        manager = multiprocessing.Manager()
+        return_dict = manager.dict()
+        p2 = multiprocessing.Process(target=send_in_parallel, args=(caller_seed, self.contractAddress, self.abi, 10, return_dict))
+        p2.start()
+        while True:
+            try:
+                send_transaction(client, self.combined_trx, self.acc)
+            except:
+                break
+        p2.join()
+        print('return_dict:', return_dict)
+        self.assertEqual(return_dict[caller_seed]['status'], 1)
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/proxy/testing/test_retry_on_blocked_accounts.py
+++ b/proxy/testing/test_retry_on_blocked_accounts.py
@@ -172,6 +172,13 @@ class BlockedTest(unittest.TestCase):
         self.combined_trx = self.make_combined_transaction(self.storage, 500, msg, instruction)
         return send_transaction(client, self.combined_trx, self.acc)
 
+    def finish_blocker_transaction(self):
+        while True:
+            try:
+                send_transaction(client, self.combined_trx, self.acc)
+            except:
+                break
+
     def get_trx_receipts(self, unsigned_msg, signature):
         trx = rlp.decode(unsigned_msg, EthTrx)
 
@@ -250,11 +257,7 @@ class BlockedTest(unittest.TestCase):
         return_dict = manager.dict()
         p2 = multiprocessing.Process(target=send_routine, args=(caller_seed, self.contractAddress, self.abi, 1000, return_dict))
         p2.start()
-        while True:
-            try:
-                send_transaction(client, self.combined_trx, self.acc)
-            except:
-                break
+        self.finish_blocker_transaction()
         p2.join()
         print('return_dict:', return_dict)
         self.assertEqual(return_dict[caller_seed]['status'], 1)
@@ -267,11 +270,7 @@ class BlockedTest(unittest.TestCase):
         return_dict = manager.dict()
         p2 = multiprocessing.Process(target=send_routine, args=(caller_seed, self.contractAddress, self.abi, 10, return_dict))
         p2.start()
-        while True:
-            try:
-                send_transaction(client, self.combined_trx, self.acc)
-            except:
-                break
+        self.finish_blocker_transaction()
         p2.join()
         print('return_dict:', return_dict)
         self.assertEqual(return_dict[caller_seed]['status'], 1)


### PR DESCRIPTION
New `RETRY_ON_BLOCKED` variable defining count of retries on blocked accounts. In `environment.py` it is set to a minimum of 1.
Removed `RuntimeError` from `confirm_multiple_transactions`.
`collect_results` and `collect_result` now return response["result"]. And all corresponding changes by removing ['result']
Write sent by packs of 20.
CombinedContinue sent by 16.
Iterative execution performed By trying to send bucked. If got error of blocked or steps exceeded - retry until success and than go back to bucked send. If there were no errors or result retry bucked.
If got error and no succec transactions sent just return error. If were success trxs try cancel.