### PR TITLE
#292 Make sure the failed receipt does not overwrite the successful receipt 

### DIFF
--- a/proxy/indexer/transactions_db.py
+++ b/proxy/indexer/transactions_db.py
@@ -65,7 +65,7 @@ class NeonTxsDB(BaseDB):
 
                 nonce VARCHAR,
                 gas_price VARCHAR,
-                gas_limit VARCHAR ,
+                gas_limit VARCHAR,
                 value VARCHAR,
                 gas_used VARCHAR,
 
@@ -143,7 +143,11 @@ class NeonTxsDB(BaseDB):
                         ON CONFLICT (neon_sign)
                         DO UPDATE SET
                             {', '.join([col+'=EXCLUDED.'+col for col in self._column_lst])}
-                        WHERE {self._table_name}.finalized=False AND EXCLUDED.finalized=True;
+                        WHERE
+                        ({self._table_name}.finalized=False AND EXCLUDED.finalized=True
+                            AND (EXCLUDED.status='0x1' OR {self._table_name}.status='0x0'))
+                        OR
+                        ({self._table_name}.status='0x0' AND EXCLUDED.status='0x1');
                        ''',
                        row)
 


### PR DESCRIPTION
Check on insert status and finalized fields. Update only records where status changed from '0x0' to '0x1' or finalized changed to from False to True with status changed from '0x0' to '0x1' or unchanged.
[sandbox with checks](https://dbfiddle.uk/?rdbms=postgres_14&fiddle=df9e489f0680ddb66898cfd6886bd31c)