### PR TITLE
Minor patches to return valid data from ETH JSON-RPC

### DIFF
--- a/proxy/environment.py
+++ b/proxy/environment.py
@@ -23,6 +23,8 @@ if MINIMAL_GAS_PRICE is not None:
 
 EXTRA_GAS = int(os.environ.get("EXTRA_GAS", "0"))
 LOG_NEON_CLI_DEBUG = os.environ.get("LOG_NEON_CLI_DEBUG", "NO") == "YES"
+# uses the "earliest" tag if "0x0" or "0" is passed to the "eth_getBlockByNumber" RPC
+USE_EARLIEST_BLOCK_IF_0_PASSED = os.environ.get("USE_EARLIEST_BLOCK_IF_0_PASSED", "NO") == "YES"
 RETRY_ON_FAIL = int(os.environ.get("RETRY_ON_FAIL", "10"))
 RETRY_ON_FAIL_ON_GETTING_CONFIRMED_TRANSACTION = max(int(os.environ.get("RETRY_ON_FAIL_ON_GETTING_CONFIRMED_TRANSACTION", "1000")), 1)
 FUZZING_BLOCKHASH = os.environ.get("FUZZING_BLOCKHASH", "NO") == "YES"

--- a/proxy/memdb/blocks_db.py
+++ b/proxy/memdb/blocks_db.py
@@ -286,13 +286,15 @@ class MemBlocksDB:
             num_len = len(hex_num)
             hex_num = '00' + hex_num.rjust(((num_len >> 1) + (num_len % 2)) << 1, '0')
             return '0x' + hex_num.rjust(64, 'f')
-
+        hash = slot_hash(block_slot)
         # TODO: return predictable information about block time
         return SolanaBlockInfo(
             slot=block_slot,
             time=(block_time or 1),
-            hash=slot_hash(block_slot),
-            parent_hash=slot_hash(block_slot - 1),
+            hash=hash,
+            # return the prev block's computed hash if the block is not the first block
+            # if the block is the first block (0x0) -- then just return the hash of this block itself
+            parent_hash=slot_hash(block_slot - 1) if block_slot > 0 else hash,
             is_fake=True
         )
 

--- a/proxy/neon_rpc_api_model/neon_rpc_api_model.py
+++ b/proxy/neon_rpc_api_model/neon_rpc_api_model.py
@@ -259,15 +259,16 @@ class NeonRpcApiModel:
             "gasLimit": '0xec8563e271ac',
             "transactionsRoot": '0x' + '0' * 63 + '1',
             "receiptsRoot": '0x' + '0' * 63 + '1',
-            "stateRoot": '0x' + '0' * 64 + '1',
+            "stateRoot": '0x' + '0' * 63 + '1',
 
             "uncles": [],
             "sha3Uncles": '0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347',
 
             "miner": '0x' + '0' * 40,
-            "nonce": '0x0',
-            "mixHash": '0x0',
-            "size": '0x0',
+            # 8 byte nonce
+            "nonce": '0x0000000000000000',
+            "mixHash": '0x' + '0' * 63 + '1',
+            "size": '0x' + '0' * 63 + '1',
 
             "gasUsed": hex(gas_used),
             "hash": block.hash,

--- a/proxy/neon_rpc_api_model/neon_rpc_api_model.py
+++ b/proxy/neon_rpc_api_model/neon_rpc_api_model.py
@@ -17,7 +17,7 @@ from ..common_neon.solana_interactor import SolanaInteractor
 from ..common_neon.utils import SolanaBlockInfo
 from ..common_neon.types import NeonTxPrecheckResult, NeonEmulatingResult
 from ..environment import SOLANA_URL, PP_SOLANA_URL, PYTH_MAPPING_ACCOUNT, NEON_EVM_VERSION, NEON_EVM_REVISION, \
-                          CHAIN_ID, neon_cli, EVM_STEP_COUNT
+                          CHAIN_ID, USE_EARLIEST_BLOCK_IF_0_PASSED, neon_cli, EVM_STEP_COUNT
 from ..memdb.memdb import MemDB
 from ..common_neon.gas_price_calculator import GasPriceCalculator
 from ..statistics_exporter.proxy_metrics_interface import StatisticsExporter
@@ -106,10 +106,13 @@ class NeonRpcApiModel:
     def __repr__(self):
         return str(self.__dict__)
 
+    def _should_return_starting_block(self, tag) -> bool:
+        return tag == 'earliest' \
+            or ((tag == '0x0' or str(tag) == '0') and USE_EARLIEST_BLOCK_IF_0_PASSED)
     def _process_block_tag(self, tag) -> SolanaBlockInfo:
         if tag in ("latest", "pending"):
             block = self._db.get_latest_block()
-        elif tag == 'earliest':
+        elif self._should_return_starting_block(tag):
             block = self._db.get_starting_block()
         elif isinstance(tag, str):
             try:


### PR DESCRIPTION
The PR includes minor changes to ensure the responses sent by the proxy are valid according to [ETH's spec](https://eth.wiki/json-rpc/API) and can be processed by services like The Graph.

1. It fixes an edge case in parent hash generation
2. validates length of placeholder hashes returned by the getBlock APIs
3. gives the option to return the earliest known block when 0x0 or 0 is passed to the eth_getBlockByNumber RPC. Enable using USE_EARLIEST_BLOCK_IF_0_PASSED env flag