### PR TITLE
#778 Remove prometheus server from CI

### DIFF
--- a/proxy/docker-compose-test.yml
+++ b/proxy/docker-compose-test.yml
@@ -219,20 +219,5 @@ services:
       - net
     entrypoint: proxy/run-indexer.sh
 
-  prometheus:
-    container_name: prometheus
-    image: prom/prometheus
-    privileged: true
-    volumes:
-      - ./statistics_exporter/config/prometheus-config.yml:/etc/prometheus/prometheus-config.yml:ro
-    command:
-      - '--config.file=/etc/prometheus/prometheus-config.yml'
-    ports:
-      - 9009:9090
-    expose:
-      - "9009"
-    networks:
-      - net
-
 networks:
   net:


### PR DESCRIPTION
Remove prometheus from CI docker-compose because it causes problems on CI and doesn't used anywhere.