### PR TITLE
Fix QueryAccount.cache warnings

### DIFF
--- a/proxy/testing/test_query_account_contract.py
+++ b/proxy/testing/test_query_account_contract.py
@@ -36,54 +36,75 @@ CONTRACT_SOURCE = '''
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0;
 
+/**
+ * @title QueryAccount
+ * @dev Wrappers around QueryAccount operations.
+ */
 library QueryAccount {
     address constant precompiled = 0xff00000000000000000000000000000000000002;
 
-    // Takes a Solana address, treats it as an address of an account.
-    // Puts the metadata and a chunk of data into the cache.
-    function cache(uint256 solana_address, uint64 offset, uint64 len) internal returns (bool) {
-        (bool success, bytes memory _dummy) = precompiled.staticcall(abi.encodeWithSignature("cache(uint256,uint64,uint64)", solana_address, offset, len));
+    /**
+     * @dev Puts the metadata and a chunk of data into the cache.
+     * @param solana_address Address of an account.
+     * @param offset Offset in bytes from the beginning of the data.
+     * @param len Length in bytes of the chunk.
+     */
+    function cache(uint256 solana_address, uint64 offset, uint64 len) internal view returns (bool) {
+        (bool success,) = precompiled.staticcall(abi.encodeWithSignature("cache(uint256,uint64,uint64)", solana_address, offset, len));
         return success;
     }
 
-    // Takes a Solana address, treats it as an address of an account.
-    // Returns the account's owner Solana address (32 bytes).
+    /**
+     * @dev Returns the account's owner Solana address.
+     * @param solana_address Address of an account.
+     */
     function owner(uint256 solana_address) internal view returns (bool, uint256) {
         (bool success, bytes memory result) = precompiled.staticcall(abi.encodeWithSignature("owner(uint256)", solana_address));
         return (success, to_uint256(result));
     }
 
-    // Takes a Solana address, treats it as an address of an account.
-    // Returns the length of the account's data (8 bytes).
+    /**
+     * @dev Returns full length of the account's data.
+     * @param solana_address Address of an account.
+     */
     function length(uint256 solana_address) internal view returns (bool, uint256) {
         (bool success, bytes memory result) = precompiled.staticcall(abi.encodeWithSignature("length(uint256)", solana_address));
         return (success, to_uint256(result));
     }
 
-    // Takes a Solana address, treats it as an address of an account.
-    // Returns the funds in lamports of the account.
+    /**
+     * @dev Returns the funds in lamports of the account.
+     * @param solana_address Address of an account.
+     */
     function lamports(uint256 solana_address) internal view returns (bool, uint256) {
         (bool success, bytes memory result) = precompiled.staticcall(abi.encodeWithSignature("lamports(uint256)", solana_address));
         return (success, to_uint256(result));
     }
 
-    // Takes a Solana address, treats it as an address of an account.
-    // Returns the executable flag of the account.
+    /**
+     * @dev Returns the executable flag of the account.
+     * @param solana_address Address of an account.
+     */
     function executable(uint256 solana_address) internal view returns (bool, bool) {
         (bool success, bytes memory result) = precompiled.staticcall(abi.encodeWithSignature("executable(uint256)", solana_address));
         return (success, to_bool(result));
     }
 
-    // Takes a Solana address, treats it as an address of an account.
-    // Returns the rent epoch of the account.
+    /**
+     * @dev Returns the rent epoch of the account.
+     * @param solana_address Address of an account.
+     */
     function rent_epoch(uint256 solana_address) internal view returns (bool, uint256) {
         (bool success, bytes memory result) = precompiled.staticcall(abi.encodeWithSignature("rent_epoch(uint256)", solana_address));
         return (success, to_uint256(result));
     }
 
-    // Takes a Solana address, treats it as an address of an account,
-    // also takes an offset and length of the account's data.
-    // Returns a chunk of the data (length bytes).
+    /**
+     * @dev Returns a chunk of the data.
+     * @param solana_address Address of an account.
+     * @param offset Offset in bytes from the beginning of the cached segment of data.
+     * @param len Length in bytes of the returning chunk.
+     */
     function data(uint256 solana_address, uint64 offset, uint64 len) internal view returns (bool, bytes memory) {
         return precompiled.staticcall(abi.encodeWithSignature("data(uint256,uint64,uint64)", solana_address, offset, len));
     }


### PR DESCRIPTION

We can make QueryAccount.cache be a view function since it does not affect the Ethereum state. Additionally, unused variable is removed.

Proof:

> Compilation warnings encountered:

    Warning: Unused local variable.
  --> project:/contracts/libraries/external/QueryAccount.sol:19:24:
   |
19 |         (bool success, bytes memory _dummy) = precompiled.staticcall(abi.enco ...
   |                        ^^^^^^^^^^^^^^^^^^^

,Warning: Function state mutability can be restricted to view
  --> project:/contracts/libraries/external/QueryAccount.sol:18:5:
   |
18 |     function cache(uint256 solana_address, uint64 offset, uint64 len) internal returns (bool) {
   |     ^ (Relevant source part starts here and spans across multiple lines).

(from sponomarev)