### PR TITLE
pythnetwork: Clean up f-string

### DIFF
--- a/proxy/common_neon/pythnetwork.py
+++ b/proxy/common_neon/pythnetwork.py
@@ -51,7 +51,7 @@ def unpack(layout_descriptor: Dict[str, Any],
     if start_idx >= len(raw_data) or stop_idx > len(raw_data):
         raise Exception(
             f"Field '{field_name}': Index overflow: len(raw_data) = {len(raw_data)}, "
-            f"start_idx = {start_idx}, stop_idx = {stop_idx}"""
+            f"start_idx = {start_idx}, stop_idx = {stop_idx}"
         )
 
     if field['format'] == 'acc':  # special case for Solana account address


### PR DESCRIPTION
This f-string for the exception has a stray `""` at the very end.